### PR TITLE
catch all errors and mark clearml task as failed with status_reason

### DIFF
--- a/machine/jobs/build_nmt_engine.py
+++ b/machine/jobs/build_nmt_engine.py
@@ -58,9 +58,9 @@ def run(args: dict) -> None:
         job.run(check_canceled)
         logger.info("Finished")
     except Exception as e:
-        logger.exception(str(e))
+        logger.exception(e, stack_info=True)
         if task:
-            task.mark_failed(status_reason=str(e))
+            task.mark_failed(status_reason=type(e).__name__, status_message=str(e))
 
 
 def main() -> None:

--- a/machine/jobs/build_nmt_engine.py
+++ b/machine/jobs/build_nmt_engine.py
@@ -22,6 +22,7 @@ logger = logging.getLogger(__package__ + ".build_nmt_engine")
 
 def run(args: dict) -> None:
     check_canceled: Optional[Callable[[], None]] = None
+    task = None
     if args["clearml"]:
         task = Task.init()
 
@@ -31,30 +32,35 @@ def run(args: dict) -> None:
 
         check_canceled = clearml_check_canceled
 
-    logger.info("NMT Engine Build Job started")
+    try:
+        logger.info("NMT Engine Build Job started")
 
-    SETTINGS.update(args)
-    SETTINGS.data_dir = os.path.expanduser(cast(str, SETTINGS.data_dir))
+        SETTINGS.update(args)
+        SETTINGS.data_dir = os.path.expanduser(cast(str, SETTINGS.data_dir))
 
-    logger.info(f"Config: {SETTINGS.as_dict()}")
+        logger.info(f"Config: {SETTINGS.as_dict()}")
 
-    shared_file_service = ClearMLSharedFileService(SETTINGS)
-    model_type = cast(str, SETTINGS.model_type).lower()
-    nmt_model_factory: NmtModelFactory
-    if model_type == "huggingface":
-        from .huggingface.hugging_face_nmt_model_factory import HuggingFaceNmtModelFactory
+        shared_file_service = ClearMLSharedFileService(SETTINGS)
+        model_type = cast(str, SETTINGS.model_type).lower()
+        nmt_model_factory: NmtModelFactory
+        if model_type == "huggingface":
+            from .huggingface.hugging_face_nmt_model_factory import HuggingFaceNmtModelFactory
 
-        nmt_model_factory = HuggingFaceNmtModelFactory(SETTINGS, shared_file_service)
-    elif model_type == "opennmt":
-        from .opennmt.open_nmt_model_factory import OpenNmtModelFactory
+            nmt_model_factory = HuggingFaceNmtModelFactory(SETTINGS, shared_file_service)
+        elif model_type == "opennmt":
+            from .opennmt.open_nmt_model_factory import OpenNmtModelFactory
 
-        nmt_model_factory = OpenNmtModelFactory(SETTINGS, shared_file_service)
-    else:
-        raise RuntimeError("The model type is invalid.")
+            nmt_model_factory = OpenNmtModelFactory(SETTINGS, shared_file_service)
+        else:
+            raise RuntimeError("The model type is invalid.")
 
-    job = NmtEngineBuildJob(SETTINGS, nmt_model_factory, shared_file_service)
-    job.run(check_canceled)
-    logger.info("Finished")
+        job = NmtEngineBuildJob(SETTINGS, nmt_model_factory, shared_file_service)
+        job.run(check_canceled)
+        logger.info("Finished")
+    except Exception as e:
+        logger.exception(str(e))
+        if task:
+            task.mark_failed(status_reason=str(e))
 
 
 def main() -> None:

--- a/machine/jobs/clearml_shared_file_service.py
+++ b/machine/jobs/clearml_shared_file_service.py
@@ -1,7 +1,7 @@
-import time
 import logging
+import time
 from pathlib import Path
-from typing import Optional, Callable
+from typing import Callable, Optional
 
 from clearml import StorageManager
 


### PR DESCRIPTION
I added a try except block that will first log any error and then, if it's running on clearml, will call `mark_failed()` with the error message as the `status_reason`. This `status_reason` can then be accessed by machine to pass along to the user.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/machine.py/29)
<!-- Reviewable:end -->
