### PR TITLE
Fix corpus count methods

### DIFF
--- a/machine/corpora/alignment_corpus.py
+++ b/machine/corpora/alignment_corpus.py
@@ -26,10 +26,6 @@ class AlignmentCorpus(Corpus[AlignmentRow]):
                 with tac.get_rows() as rows:
                     yield from rows
 
-    @property
-    def missing_rows_allowed(self) -> bool:
-        return any(ac.missing_rows_allowed for ac in self.alignment_collections)
-
     def count(self, include_empty: bool = True) -> int:
         return sum(ac.count(include_empty) for ac in self.alignment_collections)
 
@@ -63,10 +59,6 @@ class _TransformAlignmentCorpus(AlignmentCorpus):
     @property
     def alignment_collections(self) -> Iterable[AlignmentCollection]:
         return self._corpus.alignment_collections
-
-    @property
-    def missing_rows_allowed(self) -> bool:
-        return self._corpus.missing_rows_allowed
 
     def count(self, include_empty: bool = True) -> int:
         return self._corpus.count(include_empty)

--- a/machine/corpora/corpus.py
+++ b/machine/corpora/corpus.py
@@ -23,10 +23,6 @@ class Corpus(ABC, Generic[Row], Iterable[Row]):
     def __iter__(self) -> ContextManagedGenerator[Row, None, None]:
         return self.get_rows()
 
-    @property
-    def missing_rows_allowed(self) -> bool:
-        return True
-
     def count(self, include_empty: bool = True) -> int:
         with self.get_rows() as rows:
             return sum(1 for row in rows if include_empty or not row.is_empty)

--- a/machine/corpora/flatten.py
+++ b/machine/corpora/flatten.py
@@ -57,10 +57,6 @@ class _FlattenTextCorpus(TextCorpus):
     def is_tokenized(self) -> bool:
         return all(c.is_tokenized for c in self._corpora)
 
-    @property
-    def missing_rows_allowed(self) -> bool:
-        return any(c.missing_rows_allowed for c in self._corpora)
-
     def count(self, include_empty: bool = True) -> int:
         return sum(c.count(include_empty) for c in self._corpora)
 
@@ -77,10 +73,6 @@ class _FlattenAlignmentCorpus(AlignmentCorpus):
     @property
     def alignment_collections(self) -> Iterable[AlignmentCollection]:
         return chain.from_iterable(c.alignment_collections for c in self._corpora)
-
-    @property
-    def missing_rows_allowed(self) -> bool:
-        return any(c.missing_rows_allowed for c in self._corpora)
 
     def count(self, include_empty: bool = True) -> int:
         return sum(c.count(include_empty) for c in self._corpora)
@@ -102,10 +94,6 @@ class _FlattenParallelTextCorpus(ParallelTextCorpus):
     @property
     def is_target_tokenized(self) -> bool:
         return all(c.is_target_tokenized for c in self._corpora)
-
-    @property
-    def missing_rows_allowed(self) -> bool:
-        return any(c.missing_rows_allowed for c in self._corpora)
 
     def count(self, include_empty: bool = True) -> int:
         return sum(c.count(include_empty) for c in self._corpora)

--- a/machine/corpora/parallel_text_corpus.py
+++ b/machine/corpora/parallel_text_corpus.py
@@ -495,10 +495,6 @@ class _TransformParallelTextCorpus(ParallelTextCorpus):
     def is_target_tokenized(self) -> bool:
         return self._is_target_tokenized
 
-    @property
-    def missing_rows_allowed(self) -> bool:
-        return self._corpus.missing_rows_allowed
-
     def count(self, include_empty: bool = True) -> int:
         return self._corpus.count(include_empty)
 
@@ -572,10 +568,6 @@ class _PandasParallelTextCorpus(ParallelTextCorpus):
     def is_target_tokenized(self) -> bool:
         return False
 
-    @property
-    def missing_rows_allowed(self) -> bool:
-        return False
-
     def count(self, include_empty: bool = True) -> int:
         if include_empty:
             return len(self._df)
@@ -635,10 +627,6 @@ class _DatasetParallelTextCorpus(ParallelTextCorpus):
 
     @property
     def is_target_tokenized(self) -> bool:
-        return False
-
-    @property
-    def missing_rows_allowed(self) -> bool:
         return False
 
     def count(self, include_empty: bool = True) -> int:

--- a/machine/corpora/standard_parallel_text_corpus.py
+++ b/machine/corpora/standard_parallel_text_corpus.py
@@ -61,21 +61,6 @@ class StandardParallelTextCorpus(ParallelTextCorpus):
     def all_target_rows(self) -> bool:
         return self._all_target_rows
 
-    @property
-    def missing_rows_allowed(self) -> bool:
-        if self._source_corpus.missing_rows_allowed or self._target_corpus.missing_rows_allowed:
-            return True
-        source_text_ids = {t.id for t in self._source_corpus.texts}
-        target_text_ids = {t.id for t in self._target_corpus.texts}
-        return source_text_ids != target_text_ids
-
-    def count(self, include_empty: bool = True) -> int:
-        if self.missing_rows_allowed:
-            return super().count(include_empty)
-        if include_empty:
-            return self._source_corpus.count(include_empty)
-        return min(self._source_corpus.count(include_empty), self._target_corpus.count(include_empty))
-
     def _get_rows(self) -> Generator[ParallelTextRow, None, None]:
         source_text_ids = {t.id for t in self._source_corpus.texts}
         target_text_ids = {t.id for t in self._target_corpus.texts}

--- a/machine/corpora/text_corpus.py
+++ b/machine/corpora/text_corpus.py
@@ -37,10 +37,6 @@ class TextCorpus(Corpus[TextRow]):
                 with text.get_rows() as rows:
                     yield from rows
 
-    @property
-    def missing_rows_allowed(self) -> bool:
-        return any(t.missing_rows_allowed for t in self.texts)
-
     def count(self, include_empty: bool = True) -> int:
         return sum(t.count(include_empty) for t in self.texts)
 
@@ -162,10 +158,6 @@ class _TransformTextCorpus(TextCorpus):
     @property
     def is_tokenized(self) -> bool:
         return self._is_tokenized
-
-    @property
-    def missing_rows_allowed(self) -> bool:
-        return self._corpus.missing_rows_allowed
 
     def count(self, include_empty: bool = True) -> int:
         return self._corpus.count(include_empty)

--- a/machine/corpora/text_file_alignment_collection.py
+++ b/machine/corpora/text_file_alignment_collection.py
@@ -41,10 +41,18 @@ class TextFileAlignmentCollection(AlignmentCollection):
                 yield AlignmentRow(self.id, row_ref, AlignedWordPair.from_string(line))
                 line_num += 1
 
-    @property
-    def missing_rows_allowed(self) -> bool:
-        return False
-
     def count(self, include_empty: bool = True) -> int:
-        with open(self._filename, mode="rb") as file:
-            return sum(1 for line in file if include_empty or len(line.strip()) > 0)
+        if include_empty:
+            with open(self._filename, mode="rb") as file:
+                return sum(1 for _ in file)
+
+        with open(self._filename, "r", encoding="utf-8-sig") as file:
+            count = 0
+            for line in file:
+                line = line.rstrip("\r\n")
+                index = line.find("\t")
+                if index >= 0:
+                    line = line[index + 1 :]
+                if len(line.strip()) > 0:
+                    count += 1
+            return count

--- a/machine/corpora/text_file_text.py
+++ b/machine/corpora/text_file_text.py
@@ -48,10 +48,19 @@ class TextFileText(TextBase):
                 yield self._create_row(line, row_ref, flags)
                 line_num += 1
 
-    @property
-    def missing_rows_allowed(self) -> bool:
-        return False
-
     def count(self, include_empty: bool = True) -> int:
-        with open(self._filename, mode="rb") as file:
-            return sum(1 for line in file if include_empty or len(line.strip()) > 0)
+        if include_empty:
+            with open(self._filename, mode="rb") as file:
+                return sum(1 for _ in file)
+
+        with open(self._filename, mode="r", encoding="utf-8-sig") as file:
+            count = 0
+            for line in file:
+                line = line.rstrip("\r\n")
+                if len(line) > 0:
+                    columns = line.split("\t")
+                    if len(columns) > 1:
+                        line = columns[1]
+                    if len(line.strip()) > 0:
+                        count += 1
+            return count

--- a/tests/corpora/test_text_file_text.py
+++ b/tests/corpora/test_text_file_text.py
@@ -40,7 +40,7 @@ def test_get_rows_nonempty_text_no_refs() -> None:
     assert text is not None
     rows = list(text.get_rows())
 
-    assert len(rows) == 3
+    assert len(rows) == 4
 
     assert rows[0].ref == MultiKeyRef("Test3", [1])
     assert rows[0].text == "Line one."
@@ -60,3 +60,33 @@ def test_get_rows_empty_text() -> None:
     rows = list(text.get_rows())
 
     assert len(rows) == 0
+
+
+def test_count_nonempty_text_refs() -> None:
+    corpus = TextFileTextCorpus(TEXT_TEST_PROJECT_PATH)
+
+    text = corpus.get_text("Test1")
+    assert text is not None
+
+    assert text.count(include_empty=True) == 5
+    assert text.count(include_empty=False) == 4
+
+
+def test_count_nonempty_text_no_refs() -> None:
+    corpus = TextFileTextCorpus(TEXT_TEST_PROJECT_PATH)
+
+    text = corpus.get_text("Test3")
+    assert text is not None
+
+    assert text.count(include_empty=True) == 4
+    assert text.count(include_empty=False) == 3
+
+
+def test_count_empty_text() -> None:
+    corpus = TextFileTextCorpus(TEXT_TEST_PROJECT_PATH)
+
+    text = corpus.get_text("Test2")
+    assert text is not None
+
+    assert text.count(include_empty=True) == 0
+    assert text.count(include_empty=False) == 0

--- a/tests/testutils/data/txt/Test3.txt
+++ b/tests/testutils/data/txt/Test3.txt
@@ -1,3 +1,4 @@
 Line one.
 Line two.
 Line three.
+


### PR DESCRIPTION
- add support multiple columns in TextFileText.count method
- remove missing_rows_allowed property
- use standard count implementation for StandardParallelTextCorpus
- fixes #23