### PR TITLE
Fix path issue for loading from custom_normalizer directory

### DIFF
--- a/machine/translation/huggingface/hugging_face_nmt_model_trainer.py
+++ b/machine/translation/huggingface/hugging_face_nmt_model_trainer.py
@@ -201,7 +201,8 @@ class HuggingFaceNmtModelTrainer(Trainer):
                 )
             else:
                 norm_tok = PreTrainedTokenizerFast.from_pretrained(
-                    "./machine/translation/huggingface/custom_normalizer", use_fast=True
+                    str(Path(os.path.dirname(os.path.abspath(__file__))) / "custom_normalizer"),
+                    use_fast=True,
                 )
                 # using unofficially supported behavior to set the normalizer
                 tokenizer.backend_tokenizer.normalizer = norm_tok.backend_tokenizer.normalizer  # type: ignore


### PR DESCRIPTION
I changed the code so that it doesn't assume the project root directory is the same as the current working directory when loading a tokenizer from the custom_normalizer directory.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/machine.py/48)
<!-- Reviewable:end -->
