### PR TITLE
convert book abbreviation in \id marker to uppercase

### DIFF
--- a/machine/corpora/usfm_file_text.py
+++ b/machine/corpora/usfm_file_text.py
@@ -36,4 +36,4 @@ def _get_id(filename: StrPath, encoding: str) -> str:
                 if index != -1:
                     id = id[:index]
                 return id.strip().upper()
-    raise RuntimeError("The USFM does not contain and 'id' marker.")
+    raise RuntimeError("The USFM does not contain an 'id' marker.")

--- a/machine/corpora/usfm_file_text.py
+++ b/machine/corpora/usfm_file_text.py
@@ -35,5 +35,5 @@ def _get_id(filename: StrPath, encoding: str) -> str:
                 index = id.find(" ")
                 if index != -1:
                     id = id[:index]
-                return id.strip()
+                return id.strip().upper()
     raise RuntimeError("The USFM does not contain and 'id' marker.")

--- a/machine/corpora/usfm_zip_text.py
+++ b/machine/corpora/usfm_zip_text.py
@@ -43,4 +43,4 @@ def _get_id(archive_filename: StrPath, path: str, encoding: str) -> str:
                     if index != -1:
                         id = id[:index]
                     return id.strip().upper()
-    raise RuntimeError("The USFM does not contain and 'id' marker.")
+    raise RuntimeError("The USFM does not contain an 'id' marker.")

--- a/machine/corpora/usfm_zip_text.py
+++ b/machine/corpora/usfm_zip_text.py
@@ -42,5 +42,5 @@ def _get_id(archive_filename: StrPath, path: str, encoding: str) -> str:
                     index = id.find(" ")
                     if index != -1:
                         id = id[:index]
-                    return id.strip()
+                    return id.strip().upper()
     raise RuntimeError("The USFM does not contain and 'id' marker.")

--- a/tests/corpora/test_usfm_file_text.py
+++ b/tests/corpora/test_usfm_file_text.py
@@ -136,3 +136,19 @@ def test_get_rows_include_markers() -> None:
 
     assert verse_ref(rows[16]).exact_equals(VerseRef.from_string("MAT 2:10", corpus.versification))
     assert rows[16].text == "\\tc3-4 Chapter 2 verse 10"
+
+
+def test_usfm_file_text_corpus_lowercase_usfm_id() -> None:
+    corpus = UsfmFileTextCorpus(USFM_TEST_PROJECT_PATH)
+
+    text = corpus.get_text("LEV")
+    assert text is not None
+    rows = list(text)
+
+    assert len(rows) == 2
+
+    assert verse_ref(rows[0]).exact_equals(VerseRef.from_string("LEV 14:55", corpus.versification))
+    assert rows[0].text == "Chapter fourteen, verse fifty-five. Segment b."
+
+    assert verse_ref(rows[1]).exact_equals(VerseRef.from_string("LEV 14:56", corpus.versification))
+    assert rows[1].text == "Chapter fourteen, verse fifty-six."

--- a/tests/testutils/data/usfm/Tes/04LEVTes.SFM
+++ b/tests/testutils/data/usfm/Tes/04LEVTes.SFM
@@ -1,4 +1,4 @@
-\id LEV - Test
+\id lev - Test
 \h Leviticus
 \mt Leviticus
 \c 14


### PR DESCRIPTION
When retrieving the book abbreviation from the \id marker in a usfm file, convert it to uppercase, so that extracting the corpora will not result in blank output when the book id in the usfm file is lowercase.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/machine.py/60)
<!-- Reviewable:end -->
