### PR TITLE
Fixed off-by-one errors in _create_word_graph

### DIFF
--- a/machine/translation/thot/thot_smt_model.py
+++ b/machine/translation/thot/thot_smt_model.py
@@ -244,8 +244,8 @@ class ThotSmtModel(InteractiveTranslationModel):
         arcs: List[WordGraphArc] = []
         for thot_arc_id in range(thot_word_graph.num_arcs):
             thot_arc = thot_word_graph.get_arc(thot_arc_id)
-            src_phrase_len = thot_arc.source_end_index - thot_arc.source_start_index
-            source_segment_range = Range[int].create(thot_arc.source_start_index, thot_arc.source_end_index + 1)
+            src_phrase_len = thot_arc.source_end_index - (thot_arc.source_start_index - 1)
+            source_segment_range = Range[int].create(thot_arc.source_start_index - 1, thot_arc.source_end_index)
             normalized_tokens: List[str] = []
             confidences: List[float] = []
             for word in thot_arc.words:
@@ -256,7 +256,8 @@ class ThotSmtModel(InteractiveTranslationModel):
                 wa_matrix = WordAlignmentMatrix.from_word_pairs(1, 1, {(0, 0)})
             else:
                 wa_matrix = self._word_aligner.align(
-                    normalized_source_tokens[thot_arc.source_start_index : thot_arc.source_end_index], normalized_tokens
+                    normalized_source_tokens[thot_arc.source_start_index - 1 : thot_arc.source_end_index],
+                    normalized_tokens,
                 )
 
             arcs.append(
@@ -266,7 +267,7 @@ class ThotSmtModel(InteractiveTranslationModel):
                     thot_arc.score,
                     self._denormalize_target(normalized_tokens),
                     wa_matrix,
-                    Range[int].create(thot_arc.source_start_index, thot_arc.source_end_index + 1),
+                    Range[int].create(thot_arc.source_start_index - 1, thot_arc.source_end_index),
                     [TranslationSources.NONE if thot_arc.is_unknown else TranslationSources.SMT]
                     * len(normalized_tokens),
                     confidences,

--- a/tests/translation/thot/test_thot_smt_model.py
+++ b/tests/translation/thot/test_thot_smt_model.py
@@ -134,3 +134,17 @@ def _create_hmm_model() -> ThotSmtModel:
 
 def _create_fast_align_model() -> ThotSmtModel:
     return ThotSmtModel(ThotWordAlignmentModelType.FAST_ALIGN, TOY_CORPUS_FAST_ALIGN_CONFIG_FILENAME)
+
+
+def test_get_word_graph_hmm() -> None:
+    with _create_hmm_model() as smt_model:
+        word_graph = smt_model.get_word_graph("voy a marcharme hoy por la tarde .")
+        assert len(word_graph.arcs) == 2
+        assert len(word_graph.final_states) == 1
+
+
+def test_get_word_graph_fast_align() -> None:
+    with _create_fast_align_model() as smt_model:
+        word_graph = smt_model.get_word_graph("voy a marcharme hoy por la tarde .")
+        assert len(word_graph.arcs) == 2
+        assert len(word_graph.final_states) == 1


### PR DESCRIPTION
The `source_start_index` and `source_end_index` of `WordGraphArc`s seem to be 1-indexed, which was leading to index out of range errors.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/machine.py/77)
<!-- Reviewable:end -->
