### PR TITLE
swap out 600M param model for tiny for faster startup

### DIFF
--- a/machine/jobs/settings.yaml
+++ b/machine/jobs/settings.yaml
@@ -32,7 +32,7 @@ development:
       num_beams: 1
 staging:
   huggingface:
-    parent_model_name: facebook/nllb-200-distilled-600M
+    parent_model_name: hf-internal-testing/tiny-random-nllb
     train_params:
       max_steps: 10
     generate_params:


### PR DESCRIPTION
On a 3090 it saves 2 minutes per run.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/machine.py/92)
<!-- Reviewable:end -->
