### PR TITLE
Parallel to https://github.com/sillsdev/machine/pull/187

### DIFF
--- a/machine/scripture/parse.py
+++ b/machine/scripture/parse.py
@@ -44,7 +44,7 @@ def parse_selection(selection: str, versification: Versification) -> Dict[int, L
     selection = selection.strip()
     chapters = {}
 
-    if selection[-1].isdigit():  # Specific chapters from one book
+    if selection[-1].isdigit() and len(selection) > 3:  # Specific chapters from one book
         book = book_id_to_number(selection[:3])
         if book == 0:
             raise ValueError(f"{selection[:3]} is an invalid book ID.")

--- a/tests/scripture/test_parse.py
+++ b/tests/scripture/test_parse.py
@@ -36,6 +36,7 @@ def test_get_books() -> None:
 def test_get_chapters() -> None:
     assert get_chapters([]) == {}
     assert get_chapters("MAL") == {39: []}
+    assert get_chapters("PS2") == {84: []}
     assert get_chapters("GEN,EXO") == {1: [], 2: []}
     assert get_chapters("1JN,2JN") == {62: [], 63: []}
     assert get_chapters("OT") == {i: [] for i in range(1, 40)}


### PR DESCRIPTION
Fix mis-parsing of chapter selections when book name ends in a digit

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/machine.py/106)
<!-- Reviewable:end -->
