### PR TITLE
update shared_file_uri

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,7 +60,7 @@ jobs:
       - name: Test with pytest
         run: poetry run pytest --cov --cov-report=xml
       - name: Upload coverage reports to Codecov
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v4
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 

--- a/machine/jobs/settings.yaml
+++ b/machine/jobs/settings.yaml
@@ -1,6 +1,6 @@
 default:
   data_dir: ~/machine
-  shared_file_uri: s3://aqua-ml-data/
+  shared_file_uri: s3://silnlp/
   shared_file_folder: production
   pretranslation_batch_size: 1024
   huggingface:


### PR DESCRIPTION
I changed the `shared_file_uri` in `machine/jobs/settings.yaml` from aqua-ml-data to silnlp now that we've migrated to the new bucket.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/machine.py/113)
<!-- Reviewable:end -->
