### PR TITLE
fix default for BiblicalTermsListSetting

### DIFF
--- a/machine/corpora/paratext_project_settings_parser_base.py
+++ b/machine/corpora/paratext_project_settings_parser_base.py
@@ -73,7 +73,7 @@ class ParatextProjectSettingsParserBase(ABC):
             post_part = naming_elem.get("PostPart")
             if post_part:
                 suffix = post_part
-        biblical_terms_list_setting = settings_tree.getroot().findtext("BiblicalTermsListSetting", "")
+        biblical_terms_list_setting = settings_tree.getroot().findtext("BiblicalTermsListSetting")
         if biblical_terms_list_setting is None:
             # Default to Major::BiblicalTerms.xml to mirror Paratext behavior
             biblical_terms_list_setting = "Major::BiblicalTerms.xml"


### PR DESCRIPTION
The reason that `BiblicalTermsListSetting` wasn't allowed to be optional was because the default was set to `""`, but the check to see if a `BiblicalTermsListSetting` exists in the Settings.xml uses `if biblical_terms_list_setting is not None`. I've removed the explicit default so that if it's not found, it assigns `None`, and the subsequent check will work properly. This bug is only in machine.py, not in Machine.

I tested this by temporarily removing the `BiblicalTermsListSetting` line in the `Settings.xml` of the `Tes` folder, and then verifying that the change in defaults successfully changed tests from failing to passing. However, there were a couple tests that depended on the contents of `BiblicalTermsListSetting` not being empty/default, so I had to undo that change in `Settings.xml` when committing.

Should I create test case(s) for the `parse()` method in `ParatextProjectSettingsParserBase` along with this bug fix? I'd imagine that would require another test file since there isn't one for `ParatextProjectSettingsParserBase`, and then adding a corresponding test file in Machine as well to keep the repos matching.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/machine.py/125)
<!-- Reviewable:end -->
