### PR TITLE
fix deprecated tokenizer methods, add test cases

### DIFF
--- a/machine/translation/huggingface/__init__.py
+++ b/machine/translation/huggingface/__init__.py
@@ -8,6 +8,6 @@ if not is_torch_available():
 
 from .hugging_face_nmt_engine import HuggingFaceNmtEngine
 from .hugging_face_nmt_model import HuggingFaceNmtModel
-from .hugging_face_nmt_model_trainer import HuggingFaceNmtModelTrainer
+from .hugging_face_nmt_model_trainer import HuggingFaceNmtModelTrainer, add_lang_code_to_tokenizer
 
-__all__ = ["HuggingFaceNmtEngine", "HuggingFaceNmtModel", "HuggingFaceNmtModelTrainer"]
+__all__ = ["add_lang_code_to_tokenizer", "HuggingFaceNmtEngine", "HuggingFaceNmtModel", "HuggingFaceNmtModelTrainer"]

--- a/machine/translation/huggingface/hugging_face_nmt_model_trainer.py
+++ b/machine/translation/huggingface/hugging_face_nmt_model_trainer.py
@@ -24,6 +24,7 @@ from transformers import (
     NllbTokenizer,
     NllbTokenizerFast,
     PreTrainedModel,
+    PreTrainedTokenizer,
     PreTrainedTokenizerFast,
     Seq2SeqTrainer,
     Seq2SeqTrainingArguments,
@@ -218,30 +219,12 @@ class HuggingFaceNmtModelTrainer(Trainer):
                 if missing_tokens:
                     tokenizer = add_tokens(tokenizer, missing_tokens)
 
-        def add_lang_code_to_tokenizer(tokenizer: Any, lang_code: str):
-            if lang_code in tokenizer.lang_code_to_id:
-                return
-            tokenizer.add_special_tokens(
-                {"additional_special_tokens": tokenizer.additional_special_tokens + [lang_code]}
-            )
-            lang_id = tokenizer.convert_tokens_to_ids(lang_code)
-            tokenizer.lang_code_to_id[lang_code] = lang_id
-
-            if isinstance(tokenizer, (MBart50Tokenizer, MBartTokenizer)):
-                tokenizer.id_to_lang_code[lang_id] = lang_code
-                tokenizer.fairseq_tokens_to_ids[lang_code] = lang_id
-                tokenizer.fairseq_ids_to_tokens[lang_id] = lang_code
-            elif isinstance(tokenizer, M2M100Tokenizer):
-                tokenizer.lang_code_to_token[lang_code] = lang_code
-                tokenizer.lang_token_to_id[lang_code] = lang_id
-                tokenizer.id_to_lang_token[lang_id] = lang_code
-
         if isinstance(tokenizer, MULTILINGUAL_TOKENIZERS):
             logger.info("Add new language codes as tokens")
             if self._src_lang is not None:
-                add_lang_code_to_tokenizer(tokenizer, self._src_lang)
+                _add_lang_code_to_tokenizer(tokenizer, self._src_lang)
             if self._tgt_lang is not None:
-                add_lang_code_to_tokenizer(tokenizer, self._tgt_lang)
+                _add_lang_code_to_tokenizer(tokenizer, self._tgt_lang)
 
         # We resize the embeddings only when necessary to avoid index errors.
         embedding_size = cast(Any, model.get_input_embeddings()).weight.shape[0]
@@ -413,3 +396,29 @@ class _ProgressCallback(TrainerCallback):
                 if self._max_steps is None
                 else ProgressStatus.from_step(state.global_step, self._max_steps)
             )
+
+
+def _add_lang_code_to_tokenizer(tokenizer: Union[PreTrainedTokenizer, PreTrainedTokenizerFast], lang_code: str):
+    if isinstance(tokenizer, M2M100Tokenizer):
+        lang_token = "__" + lang_code + "__"
+    else:
+        lang_token = lang_code
+
+    if lang_token in tokenizer.added_tokens_encoder:
+        return
+
+    tokenizer.add_special_tokens(
+        {"additional_special_tokens": tokenizer.additional_special_tokens + [lang_token]}  # type: ignore
+    )
+    lang_id = cast(int, tokenizer.convert_tokens_to_ids(lang_token))
+
+    if isinstance(tokenizer, (MBart50Tokenizer, MBartTokenizer)):
+        tokenizer.lang_code_to_id[lang_code] = lang_id
+        tokenizer.id_to_lang_code[lang_id] = lang_code
+        tokenizer.fairseq_tokens_to_ids[lang_code] = lang_id
+        tokenizer.fairseq_ids_to_tokens[lang_id] = lang_code
+    elif isinstance(tokenizer, M2M100Tokenizer):
+        tokenizer.lang_code_to_id[lang_code] = lang_id
+        tokenizer.lang_code_to_token[lang_code] = lang_token
+        tokenizer.lang_token_to_id[lang_token] = lang_id
+        tokenizer.id_to_lang_token[lang_id] = lang_token

--- a/machine/translation/huggingface/hugging_face_nmt_model_trainer.py
+++ b/machine/translation/huggingface/hugging_face_nmt_model_trainer.py
@@ -222,9 +222,9 @@ class HuggingFaceNmtModelTrainer(Trainer):
         if isinstance(tokenizer, MULTILINGUAL_TOKENIZERS):
             logger.info("Add new language codes as tokens")
             if self._src_lang is not None:
-                _add_lang_code_to_tokenizer(tokenizer, self._src_lang)
+                add_lang_code_to_tokenizer(tokenizer, self._src_lang)
             if self._tgt_lang is not None:
-                _add_lang_code_to_tokenizer(tokenizer, self._tgt_lang)
+                add_lang_code_to_tokenizer(tokenizer, self._tgt_lang)
 
         # We resize the embeddings only when necessary to avoid index errors.
         embedding_size = cast(Any, model.get_input_embeddings()).weight.shape[0]
@@ -398,7 +398,7 @@ class _ProgressCallback(TrainerCallback):
             )
 
 
-def _add_lang_code_to_tokenizer(tokenizer: Union[PreTrainedTokenizer, PreTrainedTokenizerFast], lang_code: str):
+def add_lang_code_to_tokenizer(tokenizer: Union[PreTrainedTokenizer, PreTrainedTokenizerFast], lang_code: str):
     if isinstance(tokenizer, M2M100Tokenizer):
         lang_token = "__" + lang_code + "__"
     else:

--- a/tests/translation/huggingface/test_hugging_face_nmt_model_trainer.py
+++ b/tests/translation/huggingface/test_hugging_face_nmt_model_trainer.py
@@ -22,7 +22,7 @@ from transformers import (
 
 from machine.corpora import DictionaryTextCorpus, MemoryText, TextRow
 from machine.translation.huggingface import HuggingFaceNmtEngine, HuggingFaceNmtModelTrainer
-from machine.translation.huggingface.hugging_face_nmt_model_trainer import _add_lang_code_to_tokenizer
+from machine.translation.huggingface.hugging_face_nmt_model_trainer import add_lang_code_to_tokenizer
 
 
 def test_train_non_empty_corpus() -> None:
@@ -481,7 +481,7 @@ def test_nllb_tokenizer_add_lang_code() -> None:
     with TemporaryDirectory() as temp_dir:
         tokenizer = cast(NllbTokenizer, NllbTokenizer.from_pretrained("facebook/nllb-200-distilled-600M"))
         assert "new_lang" not in tokenizer.added_tokens_encoder
-        _add_lang_code_to_tokenizer(tokenizer, "new_lang")
+        add_lang_code_to_tokenizer(tokenizer, "new_lang")
         assert "new_lang" in tokenizer.added_tokens_encoder
         tokenizer.save_pretrained(temp_dir)
         new_tokenizer = cast(NllbTokenizer, NllbTokenizer.from_pretrained(temp_dir))
@@ -493,7 +493,7 @@ def test_nllb_tokenizer_fast_add_lang_code() -> None:
     with TemporaryDirectory() as temp_dir:
         tokenizer = cast(NllbTokenizerFast, NllbTokenizerFast.from_pretrained("facebook/nllb-200-distilled-600M"))
         assert "new_lang" not in tokenizer.added_tokens_encoder
-        _add_lang_code_to_tokenizer(tokenizer, "new_lang")
+        add_lang_code_to_tokenizer(tokenizer, "new_lang")
         assert "new_lang" in tokenizer.added_tokens_encoder
         tokenizer.save_pretrained(temp_dir)
         new_tokenizer = cast(NllbTokenizerFast, NllbTokenizerFast.from_pretrained(temp_dir))
@@ -505,7 +505,7 @@ def test_mbart_tokenizer_add_lang_code() -> None:
     with TemporaryDirectory() as temp_dir:
         tokenizer = cast(MBartTokenizer, MBartTokenizer.from_pretrained("hf-internal-testing/tiny-random-nllb"))
         assert "nl_NS" not in tokenizer.added_tokens_encoder
-        _add_lang_code_to_tokenizer(tokenizer, "nl_NS")
+        add_lang_code_to_tokenizer(tokenizer, "nl_NS")
         assert "nl_NS" in tokenizer.added_tokens_encoder
         tokenizer.save_pretrained(temp_dir)
         new_tokenizer = cast(MBartTokenizer, MBartTokenizer.from_pretrained(temp_dir))
@@ -517,7 +517,7 @@ def test_mbart_tokenizer_fast_add_lang_code() -> None:
     with TemporaryDirectory() as temp_dir:
         tokenizer = cast(MBartTokenizerFast, MBartTokenizerFast.from_pretrained("hf-internal-testing/tiny-random-nllb"))
         assert "nl_NS" not in tokenizer.added_tokens_encoder
-        _add_lang_code_to_tokenizer(tokenizer, "nl_NS")
+        add_lang_code_to_tokenizer(tokenizer, "nl_NS")
         assert "nl_NS" in tokenizer.added_tokens_encoder
         tokenizer.save_pretrained(temp_dir)
         new_tokenizer = cast(MBartTokenizerFast, MBartTokenizerFast.from_pretrained(temp_dir))
@@ -529,7 +529,7 @@ def test_mbart_50_tokenizer_add_lang_code() -> None:
     with TemporaryDirectory() as temp_dir:
         tokenizer = cast(MBart50Tokenizer, MBart50Tokenizer.from_pretrained("hf-internal-testing/tiny-random-mbart50"))
         assert "nl_NS" not in tokenizer.added_tokens_encoder
-        _add_lang_code_to_tokenizer(tokenizer, "nl_NS")
+        add_lang_code_to_tokenizer(tokenizer, "nl_NS")
         assert "nl_NS" in tokenizer.added_tokens_encoder
         tokenizer.save_pretrained(temp_dir)
         new_tokenizer = cast(MBart50Tokenizer, MBart50Tokenizer.from_pretrained(temp_dir))
@@ -543,7 +543,7 @@ def test_mbart_50_tokenizer_fast_add_lang_code() -> None:
             MBart50TokenizerFast, MBart50TokenizerFast.from_pretrained("hf-internal-testing/tiny-random-mbart50")
         )
         assert "nl_NS" not in tokenizer.added_tokens_encoder
-        _add_lang_code_to_tokenizer(tokenizer, "nl_NS")
+        add_lang_code_to_tokenizer(tokenizer, "nl_NS")
         assert "nl_NS" in tokenizer.added_tokens_encoder
         tokenizer.save_pretrained(temp_dir)
         new_tokenizer = cast(MBart50TokenizerFast, MBart50TokenizerFast.from_pretrained(temp_dir))
@@ -556,7 +556,7 @@ def test_m2m_100_tokenizer_add_lang_code() -> None:
         tokenizer = cast(M2M100Tokenizer, M2M100Tokenizer.from_pretrained("stas/tiny-m2m_100"))
         assert "nc" not in tokenizer.lang_code_to_id
         assert "__nc__" not in tokenizer.added_tokens_encoder
-        _add_lang_code_to_tokenizer(tokenizer, "nc")
+        add_lang_code_to_tokenizer(tokenizer, "nc")
         assert "nc" in tokenizer.lang_code_to_id
         assert "__nc__" in tokenizer.added_tokens_encoder
         tokenizer.save_pretrained(temp_dir)

--- a/tests/translation/huggingface/test_hugging_face_nmt_model_trainer.py
+++ b/tests/translation/huggingface/test_hugging_face_nmt_model_trainer.py
@@ -21,8 +21,7 @@ from transformers import (
 )
 
 from machine.corpora import DictionaryTextCorpus, MemoryText, TextRow
-from machine.translation.huggingface import HuggingFaceNmtEngine, HuggingFaceNmtModelTrainer
-from machine.translation.huggingface.hugging_face_nmt_model_trainer import add_lang_code_to_tokenizer
+from machine.translation.huggingface import HuggingFaceNmtEngine, HuggingFaceNmtModelTrainer, add_lang_code_to_tokenizer
 
 
 def test_train_non_empty_corpus() -> None:


### PR DESCRIPTION
This PR removes the lang_code_to_id method in places where it could be used by the NllbTokenizer, due to NllbTokenizer deprecating that method, and keeps it for the tokenizers that still use it. In its place, I compare against `tokenizer.added_tokens_encoder`, since that's what huggingface uses as their check inside their `tokenizer.convert_tokens_to_ids`, which was already being used in the `add_lang_code_to_tokenizer` method for obtaining the lang_id from the lang_code. I also added test cases for each of the different tokenizer types supported by machine.py.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/machine.py/139)
<!-- Reviewable:end -->
