### PR TITLE
Automatically run poetry install and set default python on devcontainer startup

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -32,7 +32,7 @@
 		"vscode": {
 			// Set *default* container specific settings.json values on container create.
 			"settings": {
-				"python.defaultInterpreterPath": "/usr/bin/python",
+				"python.defaultInterpreterPath": "/workspaces/machine.py/.venv/bin/python",
 				"[python]": {
 					"editor.defaultFormatter": "ms-python.black-formatter",
 					"editor.codeActionsOnSave": {
@@ -62,7 +62,8 @@
 				"GitHub.copilot"
 			]
 		}
-	}
+	},
+	"postStartCommand": "poetry install"
 	// Uncomment to connect as an existing user other than the container default. More info: https://aka.ms/dev-containers-non-root.
 	// "remoteUser": "devcontainer"
 }


### PR DESCRIPTION
This PR address #142. It automatically runs poetry install after the devcontainer starts up, and it sets the default python interpreter to the python installed in the poetry environment.