### PR TITLE
Use S3 path type

### DIFF
--- a/machine/jobs/settings.yaml
+++ b/machine/jobs/settings.yaml
@@ -1,6 +1,6 @@
 default:
   data_dir: ~/machine
-  shared_file_uri: s3://silnlp/
+  shared_file_uri: https://s3.amazonaws.com/silnlp/
   shared_file_folder: production
   inference_batch_size: 1024
   huggingface:


### PR DESCRIPTION
This is to apply the temporary fix for the S2 upload issues we were having as per https://github.com/sillsdev/serval/issues/613.  It changes the URL to the "path" URL (instead of the "virtual" one, and since the standard AWS configuration is "auto", it will detect the "path" address type and handle it appropriately.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/machine.py/152)
<!-- Reviewable:end -->
