### PR TITLE
Updates to USFM updater

### DIFF
--- a/machine/corpora/paratext_project_text_updater_base.py
+++ b/machine/corpora/paratext_project_text_updater_base.py
@@ -22,6 +22,7 @@ class ParatextProjectTextUpdaterBase(ABC):
         rows: Optional[Sequence[Tuple[Sequence[ScriptureRef], str]]] = None,
         full_name: Optional[str] = None,
         text_behavior: UpdateUsfmTextBehavior = UpdateUsfmTextBehavior.PREFER_EXISTING,
+        paragraph_behavior: UpdateUsfmMarkerBehavior = UpdateUsfmMarkerBehavior.PRESERVE,
         embed_behavior: UpdateUsfmMarkerBehavior = UpdateUsfmMarkerBehavior.PRESERVE,
         style_behavior: UpdateUsfmMarkerBehavior = UpdateUsfmMarkerBehavior.STRIP,
     ) -> Optional[str]:
@@ -31,7 +32,12 @@ class ParatextProjectTextUpdaterBase(ABC):
         with self._open(file_name) as sfm_file:
             usfm: str = sfm_file.read().decode(self._settings.encoding)
         handler = UpdateUsfmParserHandler(
-            rows, None if full_name is None else f"- {full_name}", text_behavior, embed_behavior, style_behavior
+            rows,
+            None if full_name is None else f"- {full_name}",
+            text_behavior,
+            paragraph_behavior,
+            embed_behavior,
+            style_behavior,
         )
         try:
             parse_usfm(usfm, handler, self._settings.stylesheet, self._settings.versification)

--- a/machine/corpora/paratext_project_text_updater_base.py
+++ b/machine/corpora/paratext_project_text_updater_base.py
@@ -25,6 +25,7 @@ class ParatextProjectTextUpdaterBase(ABC):
         paragraph_behavior: UpdateUsfmMarkerBehavior = UpdateUsfmMarkerBehavior.PRESERVE,
         embed_behavior: UpdateUsfmMarkerBehavior = UpdateUsfmMarkerBehavior.PRESERVE,
         style_behavior: UpdateUsfmMarkerBehavior = UpdateUsfmMarkerBehavior.STRIP,
+        preserve_paragraph_styles: Optional[Sequence[str]] = None,
     ) -> Optional[str]:
         file_name: str = self._settings.get_book_file_name(book_id)
         if not self._exists(file_name):
@@ -38,6 +39,7 @@ class ParatextProjectTextUpdaterBase(ABC):
             paragraph_behavior,
             embed_behavior,
             style_behavior,
+            preserve_paragraph_styles,
         )
         try:
             parse_usfm(usfm, handler, self._settings.stylesheet, self._settings.versification)

--- a/machine/corpora/scripture_ref_usfm_parser_handler.py
+++ b/machine/corpora/scripture_ref_usfm_parser_handler.py
@@ -19,6 +19,7 @@ class ScriptureTextType(Enum):
     NOTE_TEXT = auto()
 
 
+PRESERVE_PARAGRAPH_STYLES = ("r", "rem")
 EMBED_PART_START_CHAR_STYLES = ("f", "x", "z")
 EMBED_STYLES = ("f", "fe", "fig", "fm", "x")
 
@@ -29,6 +30,7 @@ class ScriptureRefUsfmParserHandler(UsfmParserHandler, ABC):
         self._cur_elements_stack: List[ScriptureElement] = []
         self._cur_text_type_stack: List[ScriptureTextType] = []
         self._duplicate_verse: bool = False
+        self._in_preserved_paragraph: bool = False
         self._in_embed: bool = False
         self._in_note_text: bool = False
         self._in_nested_embed: bool = False
@@ -74,6 +76,8 @@ class ScriptureRefUsfmParserHandler(UsfmParserHandler, ABC):
         unknown: Optional[bool],
         attributes: Optional[Sequence[UsfmAttribute]],
     ) -> None:
+        if self._is_preserve_paragraph_type(marker):
+            self._in_preserved_paragraph = True
         if self._cur_verse_ref.is_default:
             self._update_verse_ref(state.verse_ref, marker)
         if not state.is_verse_text:
@@ -81,6 +85,7 @@ class ScriptureRefUsfmParserHandler(UsfmParserHandler, ABC):
             self._start_non_verse_text_wrapper(state)
 
     def end_para(self, state: UsfmParserState, marker: str) -> None:
+        self._in_preserved_paragraph = False
         if self._current_text_type == ScriptureTextType.NONVERSE:
             self._end_parent_element()
             self._end_non_verse_text_wrapper(state)
@@ -270,9 +275,12 @@ class ScriptureRefUsfmParserHandler(UsfmParserHandler, ABC):
     def _is_in_embed(self, marker: Optional[str]) -> bool:
         return self._in_embed or self._is_embed_style(marker)
 
+    def _is_in_preserved_paragraph(self, marker: Optional[str]) -> bool:
+        return self._in_preserved_paragraph or self._is_preserve_paragraph_type(marker)
+
     def _is_in_nested_embed(self, marker: Optional[str]) -> bool:
         return self._in_nested_embed or (
-            marker is not None and marker[0] == "+" and marker[1] in EMBED_PART_START_CHAR_STYLES
+            marker is not None and marker.startswith("+") and marker[1] in EMBED_PART_START_CHAR_STYLES
         )
 
     def _is_note_text(self, marker: Optional[str]) -> bool:
@@ -282,4 +290,7 @@ class ScriptureRefUsfmParserHandler(UsfmParserHandler, ABC):
         return marker is not None and marker.startswith(EMBED_PART_START_CHAR_STYLES)
 
     def _is_embed_style(self, marker: Optional[str]) -> bool:
-        return marker in EMBED_STYLES
+        return marker is not None and marker.strip("*") in EMBED_STYLES
+
+    def _is_preserve_paragraph_type(self, marker: Optional[str]) -> bool:
+        return marker in PRESERVE_PARAGRAPH_STYLES

--- a/machine/corpora/scripture_ref_usfm_parser_handler.py
+++ b/machine/corpora/scripture_ref_usfm_parser_handler.py
@@ -15,11 +15,9 @@ class ScriptureTextType(Enum):
     NONE = auto()
     NONVERSE = auto()
     VERSE = auto()
-    EMBED = auto()
     NOTE_TEXT = auto()
 
 
-PRESERVE_PARAGRAPH_STYLES = ("r", "rem")
 EMBED_PART_START_CHAR_STYLES = ("f", "x", "z")
 EMBED_STYLES = ("f", "fe", "fig", "fm", "x")
 
@@ -76,8 +74,6 @@ class ScriptureRefUsfmParserHandler(UsfmParserHandler, ABC):
         unknown: Optional[bool],
         attributes: Optional[Sequence[UsfmAttribute]],
     ) -> None:
-        if self._is_preserve_paragraph_type(marker):
-            self._in_preserved_paragraph = True
         if self._cur_verse_ref.is_default:
             self._update_verse_ref(state.verse_ref, marker)
         if not state.is_verse_text:
@@ -85,7 +81,6 @@ class ScriptureRefUsfmParserHandler(UsfmParserHandler, ABC):
             self._start_non_verse_text_wrapper(state)
 
     def end_para(self, state: UsfmParserState, marker: str) -> None:
-        self._in_preserved_paragraph = False
         if self._current_text_type == ScriptureTextType.NONVERSE:
             self._end_parent_element()
             self._end_non_verse_text_wrapper(state)
@@ -275,9 +270,6 @@ class ScriptureRefUsfmParserHandler(UsfmParserHandler, ABC):
     def _is_in_embed(self, marker: Optional[str]) -> bool:
         return self._in_embed or self._is_embed_style(marker)
 
-    def _is_in_preserved_paragraph(self, marker: Optional[str]) -> bool:
-        return self._in_preserved_paragraph or self._is_preserve_paragraph_type(marker)
-
     def _is_in_nested_embed(self, marker: Optional[str]) -> bool:
         return self._in_nested_embed or (
             marker is not None and marker.startswith("+") and marker[1] in EMBED_PART_START_CHAR_STYLES
@@ -291,6 +283,3 @@ class ScriptureRefUsfmParserHandler(UsfmParserHandler, ABC):
 
     def _is_embed_style(self, marker: Optional[str]) -> bool:
         return marker is not None and marker.strip("*") in EMBED_STYLES
-
-    def _is_preserve_paragraph_type(self, marker: Optional[str]) -> bool:
-        return marker in PRESERVE_PARAGRAPH_STYLES

--- a/machine/corpora/update_usfm_parser_handler.py
+++ b/machine/corpora/update_usfm_parser_handler.py
@@ -183,7 +183,7 @@ class UpdateUsfmParserHandler(ScriptureRefUsfmParserHandler):
         scripture_ref: ScriptureRef,
     ) -> None:
         self._embed_row_texts = self._advance_rows([scripture_ref])
-        self._embed_updated = bool(self._embed_row_texts)
+        self._embed_updated = any(self._embed_row_texts)
 
         if self._replace_with_new_tokens(state):
             self._skip_tokens(state)
@@ -357,7 +357,7 @@ class UpdateUsfmParserHandler(ScriptureRefUsfmParserHandler):
         return skip_tokens
 
     def _has_new_text(self) -> bool:
-        return bool(self._replace_stack) and self._replace_stack[-1]
+        return any(self._replace_stack) and self._replace_stack[-1]
 
     def _push_new_tokens(self, tokens: List[UsfmToken]) -> None:
         self._replace_stack.append(any(tokens))

--- a/tests/corpora/test_update_usfm_parser_handler.py
+++ b/tests/corpora/test_update_usfm_parser_handler.py
@@ -35,11 +35,70 @@ def test_get_usfm_id_text() -> None:
 
 
 def test_get_usfm_strip_all_text() -> None:
-    target = update_usfm(text_behavior=UpdateUsfmTextBehavior.STRIP_EXISTING)
-    assert target is not None
-    assert "\\id MAT\r\n" in target
-    assert "\\v 1\r\n" in target
-    assert "\\s\r\n" in target
+    rows = [
+        (
+            scr_ref("MAT 1:1"),
+            str("Update 1"),
+        ),
+        (
+            scr_ref("MAT 1:3"),
+            str("Update 3"),
+        ),
+    ]
+    usfm = r"""\id MAT - Test
+\c 1
+\r keep this reference
+\rem and this reference too
+\ip but remove this text
+\v 1 Chapter \add one\add*, \p verse \f + \fr 2:1: \ft This is a \fm ∆\fm* footnote.\f*one.
+\v 2 Chapter \add one\add*, \p verse \f + \fr 2:1: \ft This is a \fm ∆\fm* footnote.\f*two.
+\v 3 Verse 3
+\v 4 Verse 4
+"""
+
+    target = update_usfm(
+        rows,
+        usfm,
+        text_behavior=UpdateUsfmTextBehavior.STRIP_EXISTING,
+        paragraph_behavior=UpdateUsfmMarkerBehavior.PRESERVE,
+        embed_behavior=UpdateUsfmMarkerBehavior.PRESERVE,
+        style_behavior=UpdateUsfmMarkerBehavior.PRESERVE,
+    )
+
+    result = r"""\id MAT
+\c 1
+\r keep this reference
+\rem and this reference too
+\ip
+\v 1 Update 1 \add \add*
+\p \f + \fr 2:1: \ft \fm ∆\fm*\f*
+\v 2 \add \add*
+\p \f + \fr 2:1: \ft \fm ∆\fm*\f*
+\v 3 Update 3
+\v 4
+"""
+    assess(target, result)
+
+    target = update_usfm(
+        rows,
+        usfm,
+        text_behavior=UpdateUsfmTextBehavior.STRIP_EXISTING,
+        paragraph_behavior=UpdateUsfmMarkerBehavior.STRIP,
+        embed_behavior=UpdateUsfmMarkerBehavior.STRIP,
+        style_behavior=UpdateUsfmMarkerBehavior.STRIP,
+    )
+
+    result = r"""\id MAT
+\c 1
+\r keep this reference
+\rem and this reference too
+\ip
+\v 1 Update 1
+\v 2
+\v 3 Update 3
+\v 4
+"""
+    assess(target, result)
 
 
 def test_get_usfm_prefer_existing():
@@ -546,6 +605,92 @@ def test_embed_style_preservation() -> None:
     assess(target, result_ss)
 
 
+def test_strip_paragraphs() -> None:
+    rows = [
+        (
+            scr_ref("MAT 1:0/2:p"),
+            str("Update Paragraph"),
+        ),
+        (
+            scr_ref("MAT 1:1"),
+            str("Update Verse 1"),
+        ),
+    ]
+    usfm = r"""\id MAT - Test
+\c 1
+\p This is a paragraph before any verses
+\p This is a second paragraph before any verses
+\v 1 Hello
+\p World
+\v 2 Hello
+\p World
+"""
+
+    target = update_usfm(rows, usfm, paragraph_behavior=UpdateUsfmMarkerBehavior.PRESERVE)
+    result_p = r"""\id MAT - Test
+\c 1
+\p This is a paragraph before any verses
+\p Update Paragraph
+\v 1 Update Verse 1
+\p
+\v 2 Hello
+\p World
+"""
+
+    assess(target, result_p)
+
+    target = update_usfm(rows, usfm, paragraph_behavior=UpdateUsfmMarkerBehavior.STRIP)
+    result_s = r"""\id MAT - Test
+\c 1
+\p This is a paragraph before any verses
+\p Update Paragraph
+\v 1 Update Verse 1
+\v 2 Hello
+\p World
+"""
+    assess(target, result_s)
+
+
+def test_preservation_raw_strings() -> None:
+    rows = [
+        (
+            scr_ref("MAT 1:1"),
+            str(r"Update all in one row \f \fr 1.1 \ft Some note \f*"),
+        )
+    ]
+    usfm = r"""\id MAT - Test
+\c 1
+\v 1 \f \fr 1.1 \ft Some note \f*Hello World
+"""
+
+    target = update_usfm(rows, usfm, embed_behavior=UpdateUsfmMarkerBehavior.STRIP)
+    result = r"""\id MAT - Test
+\c 1
+\v 1 Update all in one row \f \fr 1.1 \ft Some note \f*
+"""
+    assess(target, result)
+
+
+def test_beginning_of_verse_embed() -> None:
+    rows = [
+        (
+            scr_ref("MAT 1:1"),
+            str(r"Updated text"),
+        )
+    ]
+    usfm = r"""\id MAT - Test
+\c 1
+\v 1 \f \fr 1.1 \ft Some note \f* Text after note
+"""
+
+    target = update_usfm(rows, usfm, embed_behavior=UpdateUsfmMarkerBehavior.STRIP)
+    result = r"""\id MAT - Test
+\c 1
+\v 1 Updated text
+"""
+    assess(target, result)
+
+
 def test_empty_note() -> None:
     rows = [
         (
@@ -708,15 +853,20 @@ def update_usfm(
     source: Optional[str] = None,
     id_text: Optional[str] = None,
     text_behavior: UpdateUsfmTextBehavior = UpdateUsfmTextBehavior.PREFER_NEW,
+    paragraph_behavior: UpdateUsfmMarkerBehavior = UpdateUsfmMarkerBehavior.PRESERVE,
     embed_behavior: UpdateUsfmMarkerBehavior = UpdateUsfmMarkerBehavior.PRESERVE,
     style_behavior: UpdateUsfmMarkerBehavior = UpdateUsfmMarkerBehavior.STRIP,
 ) -> Optional[str]:
     if source is None:
         updater = FileParatextProjectTextUpdater(USFM_TEST_PROJECT_PATH)
-        return updater.update_usfm("MAT", rows, id_text, text_behavior, embed_behavior, style_behavior)
+        return updater.update_usfm(
+            "MAT", rows, id_text, text_behavior, paragraph_behavior, embed_behavior, style_behavior
+        )
     else:
         source = source.strip().replace("\r\n", "\n") + "\r\n"
-        updater = UpdateUsfmParserHandler(rows, id_text, text_behavior, embed_behavior, style_behavior)
+        updater = UpdateUsfmParserHandler(
+            rows, id_text, text_behavior, paragraph_behavior, embed_behavior, style_behavior
+        )
         parse_usfm(source, updater)
         return updater.get_usfm()
 


### PR DESCRIPTION
Add tests for beginning-of-verse embeds
Fix the embed at beginning issue (https://github.com/sillsdev/serval/issues/636)
Add paragraph marker control (https://github.com/sillsdev/serval/issues/627)
Always preserve \r and \rem
Correct behavior for stripping text behavior (https://github.com/sillsdev/serval/issues/629)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/machine.py/161)
<!-- Reviewable:end -->
