### PR TITLE
Fix colon index check

### DIFF
--- a/machine/corpora/aligned_word_pair.py
+++ b/machine/corpora/aligned_word_pair.py
@@ -26,7 +26,7 @@ class AlignedWordPair:
             alignment_score = -1
 
             second_colon_index = -1
-            if colon_index > 0:
+            if colon_index < len(token):
                 second_colon_index = token.find(":", colon_index + 1)
                 if second_colon_index > 0:
                     translation_score = float(token[colon_index + 1 : second_colon_index])

--- a/tests/corpora/test_aligned_word_pair.py
+++ b/tests/corpora/test_aligned_word_pair.py
@@ -10,6 +10,10 @@ def test_parse():
     assert len(wps) == 1
     assert wps[0].translation_score == 0.111111
     assert wps[0].alignment_score == -1
+    wps = list(AlignedWordPair.from_string("1-0"))
+    assert len(wps) == 1
+    assert wps[0].translation_score == -1
+    assert wps[0].alignment_score == -1
 
 
 def test_parse_to_string():


### PR DESCRIPTION
This was causing the function to try to set a translation score for pairs with no extra scores. I can add a test for this if you think that would be good.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/machine.py/164)
<!-- Reviewable:end -->
