### PR TITLE
Fixes for generating alignments alongside pretranslations

### DIFF
--- a/machine/jobs/build_nmt_engine.py
+++ b/machine/jobs/build_nmt_engine.py
@@ -55,6 +55,8 @@ def run(args: dict) -> None:
             except TypeError as e:
                 raise TypeError(f"Build options could not be parsed: {e}") from e
             SETTINGS.update({model_type: build_options})
+            if "align_pretranslations" in build_options:
+                SETTINGS.update({"align_pretranslations": build_options["align_pretranslations"]})
         SETTINGS.data_dir = os.path.expanduser(cast(str, SETTINGS.data_dir))
 
         logger.info(f"Config: {SETTINGS.as_dict()}")

--- a/machine/jobs/translation_file_service.py
+++ b/machine/jobs/translation_file_service.py
@@ -65,9 +65,9 @@ class TranslationFileService:
                         textId=pi["textId"],
                         refs=list(pi["refs"]),
                         translation=pi["translation"],
-                        source_tokens=list(pi["source_tokens"]),
-                        translation_tokens=list(pi["translation_tokens"]),
-                        alignment=pi["alignment"],
+                        source_tokens=list(),
+                        translation_tokens=list(),
+                        alignment="",
                     )
 
         return ContextManagedGenerator(generator())


### PR DESCRIPTION
* Make `align_pretranslations` configurable in `build_options`
* Don't try to ingest non-existent `pretranslation.src.json` properties

Related to https://github.com/sillsdev/serval/issues/663