### PR TITLE
Fix non-verse paragraph row when preceded by empty paragraph

### DIFF
--- a/machine/corpora/usfm_text_base.py
+++ b/machine/corpora/usfm_text_base.py
@@ -196,9 +196,10 @@ class _TextRowCollector(ScriptureRefUsfmParserHandler):
             text = text.rstrip("\r\n")
             if len(text) > 0:
                 if not text.isspace():
-                    for token in self._next_para_tokens:
-                        row_text += str(token)
-                    self._next_para_tokens.clear()
+                    if self._current_text_type == ScriptureTextType.VERSE:
+                        for token in self._next_para_tokens:
+                            row_text += str(token) + " "
+                        self._next_para_tokens.clear()
                     self._next_para_text_started = True
                 if len(row_text) == 0 or row_text[-1].isspace():
                     text = text.lstrip()
@@ -222,6 +223,9 @@ class _TextRowCollector(ScriptureRefUsfmParserHandler):
 
     def _end_verse_text(self, state: UsfmParserState, scripture_refs: Sequence[ScriptureRef]) -> None:
         text = self._row_texts_stack.pop()
+        if self._text._include_markers:
+            for token in self._next_para_tokens:
+                text += str(token) + " "
         self._rows.extend(self._text._create_scripture_rows(scripture_refs, text, self._sentence_start))
         self._sentence_start = (state.token and state.token.marker == "c") or has_sentence_ending(text)
 

--- a/tests/corpora/test_usfm_file_text.py
+++ b/tests/corpora/test_usfm_file_text.py
@@ -157,7 +157,7 @@ def test_get_rows_include_markers() -> None:
     assert scripture_ref(rows[0]) == ScriptureRef.parse("MAT 1:1", corpus.versification)
     assert (
         rows[0].text
-        == "Chapter \\pn one\\+pro WON\\+pro*\\pn*, verse one.\\f + \\fr 1:1: \\ft This is a footnote for v1.\\f*"
+        == "Chapter \\pn one\\+pro WON\\+pro*\\pn*, verse one.\\f + \\fr 1:1: \\ft This is a footnote for v1.\\f* \\li1"
     )
 
     assert scripture_ref(rows[1]) == ScriptureRef.parse("MAT 1:2", corpus.versification)
@@ -185,23 +185,25 @@ def test_get_rows_include_markers() -> None:
     assert not rows[11].is_range_start
 
     assert scripture_ref(rows[12]) == ScriptureRef.parse("MAT 2:4b", corpus.versification)
-    assert rows[12].text == "Chapter two, verse four."
+    assert rows[12].text == "Chapter two, verse four. \\p"
 
     assert scripture_ref(rows[13]) == ScriptureRef.parse("MAT 2:5", corpus.versification)
     assert rows[13].text == "Chapter two, verse five \\rq (MAT 3:1)\\rq*."
 
     assert scripture_ref(rows[14]) == ScriptureRef.parse("MAT 2:6", corpus.versification)
-    assert rows[14].text == 'Chapter two, verse \\w six|strong="12345" \\w*.'
+    assert rows[14].text == 'Chapter two, verse \\w six|strong="12345" \\w*. \\p'
+
+    assert scripture_ref(rows[17]) == ScriptureRef.parse("MAT 2:8", corpus.versification)
+    assert rows[17].text == "This is a list: \\b \\tr \\tc1"
 
     assert scripture_ref(rows[18]) == ScriptureRef.parse("MAT 2:9", corpus.versification)
-    assert rows[18].text == "Chapter\\tcr2 2\\tc3 verse\\tcr4 9"
+    assert rows[18].text == "Chapter\\tcr2 2\\tc3 verse\\tcr4 9 \\tr \\tc1-2"
 
     assert scripture_ref(rows[19]) == ScriptureRef.parse("MAT 2:10", corpus.versification)
     assert rows[19].text == "\\tc3-4 Chapter 2 verse 10"
 
 
 def test_get_rows_include_markers_all_text() -> None:
-
     corpus = UsfmFileTextCorpus(USFM_TEST_PROJECT_PATH, include_markers=True, include_all_text=True)
 
     text = corpus.get_text("MAT")
@@ -216,7 +218,7 @@ def test_get_rows_include_markers_all_text() -> None:
     assert scripture_ref(rows[8]) == ScriptureRef.parse("MAT 1:1", corpus.versification)
     assert (
         rows[8].text
-        == "Chapter \\pn one\\+pro WON\\+pro*\\pn*, verse one.\\f + \\fr 1:1: \\ft This is a footnote for v1.\\f*"
+        == "Chapter \\pn one\\+pro WON\\+pro*\\pn*, verse one.\\f + \\fr 1:1: \\ft This is a footnote for v1.\\f* \\li1"
     )
 
     assert scripture_ref(rows[9]) == ScriptureRef.parse("MAT 1:2", corpus.versification)

--- a/tests/corpora/test_usfm_memory_text.py
+++ b/tests/corpora/test_usfm_memory_text.py
@@ -152,6 +152,25 @@ def test_get_rows_opt_break_outside_of_segment() -> None:
     assert rows[1].text == "This is the first verse."
 
 
+def test_get_rows_paragraph_before_nonverse_paragraph() -> None:
+    rows: List[TextRow] = get_rows(
+        r"""\id MAT - Test
+\c 1
+\p
+\v 1 verse 1
+\b
+\s1 header
+\q1
+\v 2 verse 2
+""",
+        include_all_text=True,
+        include_markers=True,
+    )
+    assert len(rows) == 4, str.join(",", [tr.text for tr in rows])
+    assert rows[1].text == "verse 1 \\b \\q1"
+    assert rows[2].text == "header"
+
+
 def get_rows(usfm: str, include_markers: bool = False, include_all_text: bool = False) -> List[TextRow]:
     text = UsfmMemoryText(
         UsfmStylesheet("usfm.sty"),


### PR DESCRIPTION
- includes empty paragraph markers at end of verse rows when including markers
- fixes #188

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/machine.py/189)
<!-- Reviewable:end -->
