### PR TITLE
Handle out-of-order verses

### DIFF
--- a/machine/corpora/place_markers_usfm_update_block_handler.py
+++ b/machine/corpora/place_markers_usfm_update_block_handler.py
@@ -72,7 +72,7 @@ class PlaceMarkersUsfmUpdateBlockHandler(UsfmUpdateBlockHandler):
         trg_sent = ""
         to_place = []
         adj_src_toks = []
-        placed_elements = [elements.pop(0)] if elements[0].type == UsfmUpdateBlockElementType.OTHER else []
+        placed_elements = []
         embed_elements = []
         ignored_elements = []
         for element in elements:
@@ -98,6 +98,9 @@ class PlaceMarkersUsfmUpdateBlockHandler(UsfmUpdateBlockHandler):
             elif element.type in [UsfmUpdateBlockElementType.PARAGRAPH, UsfmUpdateBlockElementType.STYLE]:
                 to_place.append(element)
                 adj_src_toks.append(src_tok_idx)
+
+        if len(trg_sent.strip()) == 0:
+            return block
 
         trg_tok_starts = []
         prev_len = 0

--- a/tests/corpora/test_place_markers_usfm_update_block_handler.py
+++ b/tests/corpora/test_place_markers_usfm_update_block_handler.py
@@ -201,14 +201,17 @@ def test_headers() -> None:
     usfm = r"""\id MAT
 \c 1
 \s1 Start of chapter header
+\p
 \v 1 A
 \p B
 \s1 Mid-verse header
 \p C
-\s1 End of verse header
+\s1 Header between verse text and empty end-of-verse paragraphs
 \p
 \p
-\s1 Header after all paragraphs
+\p
+\s1 Header after all verse paragraphs
+\p
 \v 2 A
 \s1 Header followed by a reference
 \r (reference)
@@ -240,14 +243,17 @@ def test_headers() -> None:
     result = r"""\id MAT
 \c 1
 \s1 Start of chapter header
+\p
 \v 1 X
 \p Y
 \s1 Mid-verse header
 \p Z
-\s1 End of verse header
+\s1 Header between verse text and empty end-of-verse paragraphs
 \p
 \p
-\s1 Header after all paragraphs
+\p
+\s1 Header after all verse paragraphs
+\p
 \v 2 X
 \s1 Header followed by a reference
 \r (reference)
@@ -474,6 +480,42 @@ def test_consecutive_substring() -> None:
 \c 1
 \v 1 string
 \p ring
+"""
+    assess(target, result)
+
+
+def test_verses_out_of_order() -> None:
+    rows = [(scr_ref("MAT 1:1"), "new verse 1"), (scr_ref("MAT 1:2"), "new verse 2")]
+    usfm = r"""\id MAT
+\c 1
+\v 2 verse 2
+\v 1 verse 1
+"""
+
+    align_info = [
+        PlaceMarkersAlignmentInfo(
+            refs=["MAT 1:1"],
+            source_tokens=["verse", "1"],
+            translation_tokens=["new", "verse", "1"],
+            alignment=to_word_alignment_matrix("0-1 1-2"),
+        ),
+        PlaceMarkersAlignmentInfo(
+            refs=["MAT 1:2"],
+            source_tokens=["verse", "2"],
+            translation_tokens=["new", "verse", "2"],
+            alignment=to_word_alignment_matrix("0-1 1-2"),
+        ),
+    ]
+    target = update_usfm(
+        rows,
+        usfm,
+        text_behavior=UpdateUsfmTextBehavior.STRIP_EXISTING,
+        update_block_handlers=[PlaceMarkersUsfmUpdateBlockHandler(align_info)],
+    )
+    result = r"""\id MAT
+\c 1
+\v 2 new verse 2
+\v 1
 """
     assess(target, result)
 

--- a/tests/corpora/test_place_markers_usfm_update_block_handler.py
+++ b/tests/corpora/test_place_markers_usfm_update_block_handler.py
@@ -485,19 +485,20 @@ def test_consecutive_substring() -> None:
 
 
 def test_verses_out_of_order() -> None:
-    rows = [(scr_ref("MAT 1:1"), "new verse 1"), (scr_ref("MAT 1:2"), "new verse 2")]
+    rows = [(scr_ref("MAT 1:1"), "new verse 1 new paragraph 2"), (scr_ref("MAT 1:2"), "new verse 2")]
     usfm = r"""\id MAT
 \c 1
 \v 2 verse 2
 \v 1 verse 1
+\p paragraph 2
 """
 
     align_info = [
         PlaceMarkersAlignmentInfo(
             refs=["MAT 1:1"],
-            source_tokens=["verse", "1"],
-            translation_tokens=["new", "verse", "1"],
-            alignment=to_word_alignment_matrix("0-1 1-2"),
+            source_tokens=["verse", "1", "paragraph", "2"],
+            translation_tokens=["new", "verse", "1", "new", "paragraph", "2"],
+            alignment=to_word_alignment_matrix("0-1 1-2 2-4 3-5"),
         ),
         PlaceMarkersAlignmentInfo(
             refs=["MAT 1:2"],
@@ -516,6 +517,7 @@ def test_verses_out_of_order() -> None:
 \c 1
 \v 2 new verse 2
 \v 1
+\p
 """
     assess(target, result)
 


### PR DESCRIPTION
This prevents the code from erroring out with a confusing error message when verses are out of order.

Plus the other couple of tweaks related to the recent changes.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/machine.py/190)
<!-- Reviewable:end -->
