### PR TITLE
Use 'src' and 'trg' mirroring silnlp when src and trg lang codes are equal

### DIFF
--- a/machine/translation/huggingface/hugging_face_nmt_model_trainer.py
+++ b/machine/translation/huggingface/hugging_face_nmt_model_trainer.py
@@ -158,7 +158,10 @@ class HuggingFaceNmtModelTrainer(Trainer):
         if isinstance(self._corpus, Dataset):
             train_dataset = self._corpus
         else:
-            train_dataset = self._corpus.filter_nonempty().to_hf_dataset(src_lang, tgt_lang)
+            if src_lang == tgt_lang:
+                train_dataset = self._corpus.filter_nonempty().to_hf_dataset("src", "trg")
+            else:
+                train_dataset = self._corpus.filter_nonempty().to_hf_dataset(src_lang, tgt_lang)
 
         def find_missing_characters(tokenizer: Any, train_dataset: Dataset, lang_codes: List[str]) -> List[str]:
             vocab = tokenizer.get_vocab().keys()

--- a/machine/translation/huggingface/hugging_face_nmt_model_trainer.py
+++ b/machine/translation/huggingface/hugging_face_nmt_model_trainer.py
@@ -211,17 +211,10 @@ class HuggingFaceNmtModelTrainer(Trainer):
                 # using unofficially supported behavior to set the normalizer
                 lang_codes = []
                 tokenizer.backend_tokenizer.normalizer = norm_tok.backend_tokenizer.normalizer  # type: ignore
-                if self._add_unk_src_tokens and self._add_unk_tgt_tokens:
-                    if self._src_lang is not None:
-                        lang_codes.append(self._src_lang)
-                    if self._tgt_lang is not None:
-                        lang_codes.append(self._tgt_lang)
-                elif self._add_unk_src_tokens:
-                    if self._src_lang is not None:
-                        lang_codes.append(self._src_lang)
-                else:
-                    if self._tgt_lang is not None:
-                        lang_codes.append(self._tgt_lang)
+                if self._add_unk_src_tokens and self._src_lang is not None:
+                    lang_codes.append(self._src_lang)
+                if self._add_unk_tgt_tokens and self._tgt_lang is not None:
+                    lang_codes.append(self._tgt_lang)
                 missing_tokens = find_missing_characters(tokenizer, train_dataset, lang_codes)
                 if missing_tokens:
                     tokenizer = add_tokens(tokenizer, missing_tokens)

--- a/machine/translation/huggingface/hugging_face_nmt_model_trainer.py
+++ b/machine/translation/huggingface/hugging_face_nmt_model_trainer.py
@@ -211,10 +211,10 @@ class HuggingFaceNmtModelTrainer(Trainer):
                 # using unofficially supported behavior to set the normalizer
                 lang_codes = []
                 tokenizer.backend_tokenizer.normalizer = norm_tok.backend_tokenizer.normalizer  # type: ignore
-                if self._add_unk_src_tokens and self._src_lang is not None:
-                    lang_codes.append(self._src_lang)
-                if self._add_unk_tgt_tokens and self._tgt_lang is not None:
-                    lang_codes.append(self._tgt_lang)
+                if self._add_unk_src_tokens:
+                    lang_codes.append(src_lang)
+                if self._add_unk_tgt_tokens:
+                    lang_codes.append(tgt_lang)
                 missing_tokens = find_missing_characters(tokenizer, train_dataset, lang_codes)
                 if missing_tokens:
                     tokenizer = add_tokens(tokenizer, missing_tokens)


### PR DESCRIPTION
Can't we just always pass "src"/"trg" here? 

Fixes https://github.com/sillsdev/serval/issues/707

The issue was here:
https://github.com/sillsdev/machine.py/blob/cd2170615c2b4fef337b47ad2bc760db9aca0899/machine/corpora/parallel_text_corpus.py#L429

When `source_lang` and `target_lang` are equal, the dictionary definition collapses to just one of the items. 

I have yet to test the complete pipeline. But I plan to publish a development docker image and then test E2E through local Serval.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/machine.py/199)
<!-- Reviewable:end -->
