### PR TITLE
Add support to add tags to the ClearML task via build_options

### DIFF
--- a/machine/jobs/build_clearml_helper.py
+++ b/machine/jobs/build_clearml_helper.py
@@ -110,7 +110,7 @@ def get_local_progress_caller(progress_info: ProgressInfo, logger: logging.Logge
     return local_progress
 
 
-def update_settings(settings: Settings, args: dict):
+def update_settings(settings: Settings, args: dict, task: Optional[Task], logger: logging.Logger):
     settings.update(args)
     settings.model_type = cast(str, settings.model_type).lower()
     if "build_options" in settings:
@@ -121,4 +121,11 @@ def update_settings(settings: Settings, args: dict):
         except TypeError as e:
             raise TypeError(f"Build options could not be parsed: {e}") from e
         settings.update({settings.model_type: build_options})
+        if "align_pretranslations" in build_options:
+            settings.update({"align_pretranslations": build_options["align_pretranslations"]})
+        if task is not None and "tags" in build_options:
+            tags = build_options["tags"]
+            if isinstance(tags, str) or (isinstance(tags, list) and all(isinstance(tag, str) for tag in tags)):
+                task.add_tags(tags)
     settings.data_dir = os.path.expanduser(cast(str, settings.data_dir))
+    logger.info(f"Config: {settings.as_dict()}")

--- a/machine/jobs/build_smt_engine.py
+++ b/machine/jobs/build_smt_engine.py
@@ -46,9 +46,7 @@ def run(args: dict) -> None:
 
     try:
         logger.info("SMT Engine Build Job started")
-        update_settings(SETTINGS, args)
-
-        logger.info(f"Config: {SETTINGS.as_dict()}")
+        update_settings(SETTINGS, args, task, logger)
 
         shared_file_service = TranslationFileService(SharedFileServiceType.CLEARML, SETTINGS)
         smt_model_factory: SmtModelFactory

--- a/machine/jobs/build_word_alignment_model.py
+++ b/machine/jobs/build_word_alignment_model.py
@@ -47,9 +47,7 @@ def run(args: dict):
 
     try:
         logger.info("Word Alignment Build Job started")
-        update_settings(SETTINGS, args)
-
-        logger.info(f"Config: {SETTINGS.as_dict()}")
+        update_settings(SETTINGS, args, task, logger)
 
         word_alignment_file_service = WordAlignmentFileService(SharedFileServiceType.CLEARML, SETTINGS)
         word_alignment_model_factory: WordAlignmentModelFactory


### PR DESCRIPTION
Fixes https://github.com/sillsdev/serval/issues/709

This PR adds support for specifying tags via `build_options`, for example:

```py
from machine.jobs.build_smt_engine import run
args = {
    'model_type': 'thot',
    'engine_id': '6848db0e6062343fa1d3a472',
    'build_id': '687715134a39e1ae2909b94d',
    'shared_file_uri': 's3://silnlp',
    'shared_file_folder': 'docker-compose/',
    'build_options': '''{"tags":"sf-dev"}''',
    'clearml': True
}
run(args)
```

The job in ClearML then will display as follows:
<img width="526" height="327" alt="image" src="https://github.com/user-attachments/assets/d2d2020a-bfa9-4b57-8db4-194a4c3ed572" />

The build options will be configured in Scripture Forge. No change to Serval is required.
