### PR TITLE
Dockerfile updates

### DIFF
--- a/dockerfile
+++ b/dockerfile
@@ -3,7 +3,7 @@ ARG PYTHON_VERSION=3.12
 ARG UBUNTU_VERSION=noble
 ARG POETRY_VERSION=1.6.1
 
-FROM python:$PYTHON_VERSION-slim AS builder
+FROM python:$PYTHON_VERSION-slim-bookworm AS builder
 ARG POETRY_VERSION
 
 ENV POETRY_HOME=/opt/poetry
@@ -23,7 +23,7 @@ COPY poetry.lock pyproject.toml /src
 RUN poetry export --with=gpu --without-hashes -f requirements.txt > requirements.txt
 
 
-FROM python:$PYTHON_VERSION-slim
+FROM python:$PYTHON_VERSION-slim-bookworm
 ARG PYTHON_VERSION
 
 ENV PIP_DISABLE_PIP_VERSION_CHECK=on


### PR DESCRIPTION
The main change is that I 'reverted' to bookworm. We should consider updating to trixie, but it's probably better to be more explicit anyways and *intentionally* make that change - not have it quietly forced upon us. I also switched to the slim image. All we needed that wasn't in slim were things to build eflomal (make, gcc, ...) which cut down the image size a few hundred megabytes. Also, I removed the links because they weren't really doing anything.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/machine.py/216)
<!-- Reviewable:end -->
