### PR TITLE
Detect quote convention from file Paratext project

### DIFF
--- a/machine/corpora/file_paratext_project_quote_convention_detector.py
+++ b/machine/corpora/file_paratext_project_quote_convention_detector.py
@@ -1,0 +1,19 @@
+from pathlib import Path
+from typing import BinaryIO, Optional
+
+from ..utils.typeshed import StrPath
+from .file_paratext_project_settings_parser import FileParatextProjectSettingsParser
+from .paratext_project_quote_convention_detector import ParatextProjectQuoteConventionDetector
+
+
+class FileParatextProjectQuoteConventionDetector(ParatextProjectQuoteConventionDetector):
+    def __init__(self, project_dir: StrPath) -> None:
+        super().__init__(FileParatextProjectSettingsParser(project_dir))
+
+        self._project_dir = project_dir
+
+    def _exists(self, file_name: str) -> bool:
+        return (Path(self._project_dir) / file_name).exists()
+
+    def _open(self, file_name: str) -> Optional[BinaryIO]:
+        return open(Path(self._project_dir) / file_name, mode="rb")

--- a/machine/corpora/file_paratext_project_quote_convention_detector.py
+++ b/machine/corpora/file_paratext_project_quote_convention_detector.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from typing import BinaryIO, Optional
+from typing import BinaryIO
 
 from ..utils.typeshed import StrPath
 from .file_paratext_project_settings_parser import FileParatextProjectSettingsParser
@@ -15,5 +15,5 @@ class FileParatextProjectQuoteConventionDetector(ParatextProjectQuoteConventionD
     def _exists(self, file_name: str) -> bool:
         return (Path(self._project_dir) / file_name).exists()
 
-    def _open(self, file_name: str) -> Optional[BinaryIO]:
+    def _open(self, file_name: StrPath) -> BinaryIO:
         return open(Path(self._project_dir) / file_name, mode="rb")


### PR DESCRIPTION
This PR adds a class that can detect the quote convention for a Paratext project from a project directory.  This class will primarily be used by SILNLP to detect the quote convention for the source and target projects.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/machine.py/224)
<!-- Reviewable:end -->
