### PR TITLE
Add Normalization Form and Language to ParatextSettingsParser

### DIFF
--- a/machine/corpora/paratext_project_settings.py
+++ b/machine/corpora/paratext_project_settings.py
@@ -23,6 +23,8 @@ class ParatextProjectSettings:
     language_code: Optional[str]
     translation_type: str
     visibility: Optional[str] = None
+    normalization_form: str
+    language: str
     parent_guid: Optional[str] = None
     parent_name: Optional[str] = None
     _parent: Optional["ParatextProjectSettings"] = None

--- a/machine/corpora/paratext_project_settings.py
+++ b/machine/corpora/paratext_project_settings.py
@@ -22,9 +22,9 @@ class ParatextProjectSettings:
     biblical_terms_file_name: str
     language_code: Optional[str]
     translation_type: str
-    visibility: Optional[str] = None
     normalization_form: str
     language: str
+    visibility: Optional[str] = None
     parent_guid: Optional[str] = None
     parent_name: Optional[str] = None
     _parent: Optional["ParatextProjectSettings"] = None

--- a/machine/corpora/paratext_project_settings_parser_base.py
+++ b/machine/corpora/paratext_project_settings_parser_base.py
@@ -100,6 +100,9 @@ class ParatextProjectSettingsParserBase(ABC):
                 parent_guid = translation_info_setting_parts[2] if translation_info_setting_parts[2] != "" else None
 
         visibility: Optional[str] = settings_tree.getroot().findtext("Visibility")
+        normalization_form: str = settings_tree.getroot().findtext("NormalizationForm", "Off")
+
+        language: str = settings_tree.getroot().findtext("Language", "en")
 
         settings = ParatextProjectSettings(
             guid,
@@ -117,6 +120,8 @@ class ParatextProjectSettingsParserBase(ABC):
             language_code,
             translation_type,
             visibility,
+            normalization_form,
+            language,
             parent_guid,
             parent_name,
         )

--- a/machine/corpora/paratext_project_settings_parser_base.py
+++ b/machine/corpora/paratext_project_settings_parser_base.py
@@ -102,7 +102,7 @@ class ParatextProjectSettingsParserBase(ABC):
         visibility: Optional[str] = settings_tree.getroot().findtext("Visibility")
         normalization_form: str = settings_tree.getroot().findtext("NormalizationForm", "Off")
 
-        language: str = settings_tree.getroot().findtext("Language", "en")
+        language: str = settings_tree.getroot().findtext("Language", "")
 
         settings = ParatextProjectSettings(
             guid,

--- a/machine/corpora/paratext_project_settings_parser_base.py
+++ b/machine/corpora/paratext_project_settings_parser_base.py
@@ -100,7 +100,7 @@ class ParatextProjectSettingsParserBase(ABC):
                 parent_guid = translation_info_setting_parts[2] if translation_info_setting_parts[2] != "" else None
 
         visibility: Optional[str] = settings_tree.getroot().findtext("Visibility")
-        normalization_form: str = settings_tree.getroot().findtext("NormalizationForm", "Off")
+        normalization_form: str = settings_tree.getroot().findtext("NormalizationForm", "Undefined")
 
         language: str = settings_tree.getroot().findtext("Language", "")
 
@@ -119,9 +119,9 @@ class ParatextProjectSettingsParserBase(ABC):
             parts[2],
             language_code,
             translation_type,
-            visibility,
             normalization_form,
             language,
+            visibility,
             parent_guid,
             parent_name,
         )

--- a/tests/corpora/test_paratext_project_settings.py
+++ b/tests/corpora/test_paratext_project_settings.py
@@ -129,5 +129,7 @@ def _create_settings(file_name_form: str) -> ParatextProjectSettings:
         "BiblicalTerms.xml",
         "en",
         "Standard",
+        "Undefined",
+        "English",
         "Public",
     )

--- a/tests/corpora/test_paratext_project_settings_parser.py
+++ b/tests/corpora/test_paratext_project_settings_parser.py
@@ -24,6 +24,11 @@ def test_translation_info_specified() -> None:
     assert settings.parent_name == "DEF"
     assert settings.parent_guid == "22222222222222222222222222222222"
 
+def test_normalization_form_default() -> None:
+    settings = _create_settings()
+
+    assert settings.normalization_form == "Undefined"
+
 
 def _create_settings(additional_settings_xml: str = ""):
     files = {

--- a/tests/corpora/test_paratext_project_settings_parser.py
+++ b/tests/corpora/test_paratext_project_settings_parser.py
@@ -24,6 +24,7 @@ def test_translation_info_specified() -> None:
     assert settings.parent_name == "DEF"
     assert settings.parent_guid == "22222222222222222222222222222222"
 
+
 def test_normalization_form_default() -> None:
     settings = _create_settings()
 

--- a/tests/testutils/memory_paratext_project_file_handler.py
+++ b/tests/testutils/memory_paratext_project_file_handler.py
@@ -50,6 +50,8 @@ class DefaultParatextProjectSettings(ParatextProjectSettings):
         biblical_terms_file_name: str = "ProjectBiblicalTerms.xml",
         language_code: str = "en",
         translation_type: str = "Standard",
+        normalization_form: str = "Undefined",
+        language: str = "",
         parent_guid: Optional[str] = None,
         parent_name: Optional[str] = None,
     ):
@@ -69,6 +71,8 @@ class DefaultParatextProjectSettings(ParatextProjectSettings):
             biblical_terms_file_name,
             language_code,
             translation_type,
+            normalization_form,
+            language,
             parent_guid,
             parent_name,
         )


### PR DESCRIPTION
This PR add `normalization_form` and `language` to `ParatextProjectSettings`, from the `NormalizationForm` and `Language` fields in a project's `Settings.xml` file. These are both wanted for some improved Onboarding information collection.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/machine.py/313)
<!-- Reviewable:end -->
