### PR TITLE
Port ChrF3QualityEstimator from SIL.Machine

### DIFF
--- a/machine/quality_estimation/__init__.py
+++ b/machine/quality_estimation/__init__.py
@@ -1,0 +1,23 @@
+from .chrf3_quality_estimator import ChrF3QualityEstimator
+from .scripture_book_usability import ScriptureBookUsability
+from .scripture_chapter_usability import ScriptureChapterUsability
+from .scripture_segment_usability import ScriptureSegmentUsability
+from .text_segment_usability import TextSegmentUsability
+from .text_usability import TextUsability
+from .thresholds import Thresholds
+from .usability_base import UsabilityBase
+from .usability_label import UsabilityLabel
+from .usability_parameters import UsabilityParameters
+
+__all__ = [
+    "ChrF3QualityEstimator",
+    "ScriptureBookUsability",
+    "ScriptureChapterUsability",
+    "ScriptureSegmentUsability",
+    "TextSegmentUsability",
+    "TextUsability",
+    "Thresholds",
+    "UsabilityBase",
+    "UsabilityLabel",
+    "UsabilityParameters",
+]

--- a/machine/quality_estimation/chrf3_quality_estimator.py
+++ b/machine/quality_estimation/chrf3_quality_estimator.py
@@ -1,8 +1,6 @@
 import math
 from collections import defaultdict
-from typing import Iterable, overload
-
-from scipy.stats import gmean
+from typing import Iterable, List, Type, cast, overload
 
 from ..corpora import MultiKeyRef, ScriptureRef
 from .score import Score
@@ -39,30 +37,36 @@ class ChrF3QualityEstimator:
 
     @overload
     def estimate_quality(
-        self, confidences: Iterable[tuple[ScriptureRef, float]]
-    ) -> tuple[list[ScriptureSegmentUsability], list[ScriptureChapterUsability], list[ScriptureBookUsability]]: ...
+        self, confidences: Iterable[tuple[MultiKeyRef, float]], ref_type: Type[MultiKeyRef] = MultiKeyRef
+    ) -> tuple[list[TextSegmentUsability], list[TextUsability]]: ...
 
     @overload
     def estimate_quality(
-        self, confidences: Iterable[tuple[MultiKeyRef, float]]
-    ) -> tuple[list[TextSegmentUsability], list[TextUsability]]: ...
+        self, confidences: Iterable[tuple[ScriptureRef, float]], ref_type: Type[ScriptureRef] = ScriptureRef
+    ) -> tuple[list[ScriptureSegmentUsability], list[ScriptureChapterUsability], list[ScriptureBookUsability]]: ...
 
     def estimate_quality(
-        self, confidences: Iterable[tuple[ScriptureRef, float]] | Iterable[tuple[MultiKeyRef, float]]
+        self,
+        confidences: Iterable[tuple[ScriptureRef, float] | tuple[MultiKeyRef, float]],
+        ref_type: Type[ScriptureRef | MultiKeyRef] = ScriptureRef,
     ) -> (
         tuple[list[ScriptureSegmentUsability], list[ScriptureChapterUsability], list[ScriptureBookUsability]]
         | tuple[list[TextSegmentUsability], list[TextUsability]]
     ):
         confidences_list = list(confidences)
         if not confidences_list:
-            return ([], []) if isinstance(confidences_list[0][0], MultiKeyRef) else ([], [], [])
+            return ([], []) if issubclass(ref_type, MultiKeyRef) else ([], [], [])
 
         first_key = confidences_list[0][0]
-        if hasattr(first_key, "book"):
-            segment_scores, chapter_scores, book_scores = self._project_chrf3_scripture(confidences_list)
+        if isinstance(first_key, ScriptureRef):
+            segment_scores, chapter_scores, book_scores = self._project_chrf3_scripture(
+                cast(List[tuple[ScriptureRef, float]], confidences_list)
+            )
             return self._compute_segment_usability_scripture(segment_scores, chapter_scores, book_scores)
         else:
-            segment_scores, text_scores = self._project_chrf3_text(confidences_list)
+            segment_scores, text_scores = self._project_chrf3_text(
+                cast(List[tuple[MultiKeyRef, float]], confidences_list)
+            )
             return self._compute_segment_usability_text(segment_scores, text_scores)
 
     def _calculate_usable_probability(self, chrf3: float) -> float:
@@ -179,7 +183,15 @@ class ChrF3QualityEstimator:
             )
         return usability_texts
 
-    def _project_chrf3_text(self, confidences) -> tuple[list[TextSegmentScore], TextScores]:
+    @staticmethod
+    def _gmean(values: List[float]) -> float:
+        if not values or any(x <= 0 for x in values):
+            return 0.0
+        return math.exp(sum(math.log(x) for x in values) / len(values))
+
+    def _project_chrf3_text(
+        self, confidences: List[tuple[MultiKeyRef, float]]
+    ) -> tuple[list[TextSegmentScore], TextScores]:
         confidences_by_text_id = defaultdict(list)
         segment_scores = []
         for segment_ref, confidence in confidences:
@@ -189,11 +201,11 @@ class ChrF3QualityEstimator:
 
         text_scores = TextScores()
         for text_id, values in confidences_by_text_id.items():
-            text_scores.add_score(text_id, Score(self._slope, gmean(values), self._intercept))
+            text_scores.add_score(text_id, Score(self._slope, self._gmean(values), self._intercept))
         return segment_scores, text_scores
 
     def _project_chrf3_scripture(
-        self, confidences
+        self, confidences: List[tuple[ScriptureRef, float]]
     ) -> tuple[list[ScriptureSegmentScore], ScriptureChapterScores, ScriptureBookScores]:
         confidences_by_book = defaultdict(list)
         confidences_by_book_and_chapter = defaultdict(list)
@@ -208,9 +220,9 @@ class ChrF3QualityEstimator:
 
         chapter_scores = ScriptureChapterScores()
         for (book, chapter), values in confidences_by_book_and_chapter.items():
-            chapter_scores.add_score(book, chapter, Score(self._slope, gmean(values), self._intercept))
+            chapter_scores.add_score(book, chapter, Score(self._slope, self._gmean(values), self._intercept))
 
         book_scores = ScriptureBookScores()
         for book, values in confidences_by_book.items():
-            book_scores.add_score(book, Score(self._slope, gmean(values), self._intercept))
+            book_scores.add_score(book, Score(self._slope, self._gmean(values), self._intercept))
         return segment_scores, chapter_scores, book_scores

--- a/machine/quality_estimation/chrf3_quality_estimator.py
+++ b/machine/quality_estimation/chrf3_quality_estimator.py
@@ -1,0 +1,216 @@
+import math
+from collections import defaultdict
+from typing import Iterable, overload
+
+from scipy.stats import gmean
+
+from ..corpora import MultiKeyRef, ScriptureRef
+from .score import Score
+from .scripture_book_scores import ScriptureBookScores
+from .scripture_book_usability import ScriptureBookUsability
+from .scripture_chapter_scores import ScriptureChapterScores
+from .scripture_chapter_usability import ScriptureChapterUsability
+from .scripture_segment_score import ScriptureSegmentScore
+from .scripture_segment_usability import ScriptureSegmentUsability
+from .text_scores import TextScores
+from .text_segment_score import TextSegmentScore
+from .text_segment_usability import TextSegmentUsability
+from .text_usability import TextUsability
+from .thresholds import Thresholds
+from .usability_parameters import UsabilityParameters
+
+
+class ChrF3QualityEstimator:
+    GREEN_THRESHOLD = 0.776
+    YELLOW_THRESHOLD = 0.681
+
+    def __init__(self, slope: float, intercept: float) -> None:
+        self._slope = slope
+        self._intercept = intercept
+        self.book_thresholds = Thresholds(green_threshold=self.GREEN_THRESHOLD, yellow_threshold=self.YELLOW_THRESHOLD)
+        self.chapter_thresholds = Thresholds(
+            green_threshold=self.GREEN_THRESHOLD, yellow_threshold=self.YELLOW_THRESHOLD
+        )
+        self.segment_thresholds = Thresholds(
+            green_threshold=self.GREEN_THRESHOLD, yellow_threshold=self.YELLOW_THRESHOLD
+        )
+        self.usable = UsabilityParameters.usable
+        self.unusable = UsabilityParameters.unusable
+
+    @overload
+    def estimate_quality(
+        self, confidences: Iterable[tuple[ScriptureRef, float]]
+    ) -> tuple[list[ScriptureSegmentUsability], list[ScriptureChapterUsability], list[ScriptureBookUsability]]: ...
+
+    @overload
+    def estimate_quality(
+        self, confidences: Iterable[tuple[MultiKeyRef, float]]
+    ) -> tuple[list[TextSegmentUsability], list[TextUsability]]: ...
+
+    def estimate_quality(
+        self, confidences: Iterable[tuple[ScriptureRef, float]] | Iterable[tuple[MultiKeyRef, float]]
+    ) -> (
+        tuple[list[ScriptureSegmentUsability], list[ScriptureChapterUsability], list[ScriptureBookUsability]]
+        | tuple[list[TextSegmentUsability], list[TextUsability]]
+    ):
+        confidences_list = list(confidences)
+        if not confidences_list:
+            return ([], []) if isinstance(confidences_list[0][0], MultiKeyRef) else ([], [], [])
+
+        first_key = confidences_list[0][0]
+        if hasattr(first_key, "book"):
+            segment_scores, chapter_scores, book_scores = self._project_chrf3_scripture(confidences_list)
+            return self._compute_segment_usability_scripture(segment_scores, chapter_scores, book_scores)
+        else:
+            segment_scores, text_scores = self._project_chrf3_text(confidences_list)
+            return self._compute_segment_usability_text(segment_scores, text_scores)
+
+    def _calculate_usable_probability(self, chrf3: float) -> float:
+        usable_weight = math.exp(-((chrf3 - self.usable.mean) ** 2) / (2 * self.usable.variance)) * self.usable.count
+        unusable_weight = (
+            math.exp(-((chrf3 - self.unusable.mean) ** 2) / (2 * self.unusable.variance)) * self.unusable.count
+        )
+        return usable_weight / (usable_weight + unusable_weight)
+
+    def _compute_book_usability(self, book_scores: ScriptureBookScores) -> list[ScriptureBookUsability]:
+        usability_books = []
+        for book in book_scores.scores.keys():
+            score = book_scores.get_score(book)
+            if score is None:
+                continue
+            book_usabilities = book_scores.get_segment_usabilities(book)
+            average_probability = sum(book_usabilities) / len(book_usabilities) if book_usabilities else 0.0
+            usability_books.append(
+                ScriptureBookUsability(
+                    book=book,
+                    label=self.book_thresholds.return_label(average_probability),
+                    usability=average_probability,
+                    projected_chrf3=score.projected_chrf3,
+                    confidence=score.confidence,
+                )
+            )
+        return usability_books
+
+    def _compute_chapter_usability(self, chapter_scores: ScriptureChapterScores) -> list[ScriptureChapterUsability]:
+        usability_chapters = []
+        for book, chapter_dict in chapter_scores.scores.items():
+            for chapter in chapter_dict.keys():
+                score = chapter_scores.get_score(book, chapter)
+                if score is None:
+                    continue
+                chapter_usabilities = chapter_scores.get_segment_usabilities(book, chapter)
+                average_probability = (
+                    sum(chapter_usabilities) / len(chapter_usabilities) if chapter_usabilities else 0.0
+                )
+                usability_chapters.append(
+                    ScriptureChapterUsability(
+                        book=book,
+                        chapter=chapter,
+                        label=self.chapter_thresholds.return_label(average_probability),
+                        usability=average_probability,
+                        projected_chrf3=score.projected_chrf3,
+                        confidence=score.confidence,
+                    )
+                )
+        return usability_chapters
+
+    def _compute_segment_usability_scripture(
+        self,
+        segment_scores: list[ScriptureSegmentScore],
+        chapter_scores: ScriptureChapterScores,
+        book_scores: ScriptureBookScores,
+    ) -> tuple[list[ScriptureSegmentUsability], list[ScriptureChapterUsability], list[ScriptureBookUsability]]:
+        usability_segments = []
+        for segment_score in segment_scores:
+            probability = self._calculate_usable_probability(segment_score.projected_chrf3)
+            chapter_scores.append_segment_usability(
+                segment_score.scripture_ref.book, segment_score.scripture_ref.chapter_num, probability
+            )
+            book_scores.append_segment_usability(segment_score.scripture_ref.book, probability)
+            usability_segments.append(
+                ScriptureSegmentUsability(
+                    scripture_ref=segment_score.scripture_ref,
+                    label=self.segment_thresholds.return_label(probability),
+                    usability=probability,
+                    projected_chrf3=segment_score.projected_chrf3,
+                    confidence=segment_score.confidence,
+                )
+            )
+        return (
+            usability_segments,
+            self._compute_chapter_usability(chapter_scores),
+            self._compute_book_usability(book_scores),
+        )
+
+    def _compute_segment_usability_text(
+        self, segment_scores: list[TextSegmentScore], text_scores: TextScores
+    ) -> tuple[list[TextSegmentUsability], list[TextUsability]]:
+        usability_segments = []
+        for segment_score in segment_scores:
+            probability = self._calculate_usable_probability(segment_score.projected_chrf3)
+            text_scores.append_segment_usability(segment_score.text_id, probability)
+            usability_segments.append(
+                TextSegmentUsability(
+                    segment_ref=segment_score.segment_ref,
+                    label=self.segment_thresholds.return_label(probability),
+                    usability=probability,
+                    projected_chrf3=segment_score.projected_chrf3,
+                    confidence=segment_score.confidence,
+                )
+            )
+        return usability_segments, self._compute_text_usability(text_scores)
+
+    def _compute_text_usability(self, text_scores: TextScores) -> list[TextUsability]:
+        usability_texts = []
+        for text_id in text_scores.scores.keys():
+            score = text_scores.get_score(text_id)
+            if score is None:
+                continue
+            text_usabilities = text_scores.get_segment_usabilities(text_id)
+            average_probability = sum(text_usabilities) / len(text_usabilities) if text_usabilities else 0.0
+            usability_texts.append(
+                TextUsability(
+                    text_id=text_id,
+                    label=self.book_thresholds.return_label(average_probability),
+                    usability=average_probability,
+                    projected_chrf3=score.projected_chrf3,
+                    confidence=score.confidence,
+                )
+            )
+        return usability_texts
+
+    def _project_chrf3_text(self, confidences) -> tuple[list[TextSegmentScore], TextScores]:
+        confidences_by_text_id = defaultdict(list)
+        segment_scores = []
+        for segment_ref, confidence in confidences:
+            score = TextSegmentScore(self._slope, confidence, self._intercept, segment_ref)
+            segment_scores.append(score)
+            confidences_by_text_id[segment_ref.text_id].append(confidence)
+
+        text_scores = TextScores()
+        for text_id, values in confidences_by_text_id.items():
+            text_scores.add_score(text_id, Score(self._slope, gmean(values), self._intercept))
+        return segment_scores, text_scores
+
+    def _project_chrf3_scripture(
+        self, confidences
+    ) -> tuple[list[ScriptureSegmentScore], ScriptureChapterScores, ScriptureBookScores]:
+        confidences_by_book = defaultdict(list)
+        confidences_by_book_and_chapter = defaultdict(list)
+        segment_scores = []
+        for scripture_ref, confidence in confidences:
+            score = ScriptureSegmentScore(self._slope, confidence, self._intercept, scripture_ref)
+            segment_scores.append(score)
+            book = scripture_ref.book
+            chapter = scripture_ref.chapter_num
+            confidences_by_book_and_chapter[(book, chapter)].append(confidence)
+            confidences_by_book[book].append(confidence)
+
+        chapter_scores = ScriptureChapterScores()
+        for (book, chapter), values in confidences_by_book_and_chapter.items():
+            chapter_scores.add_score(book, chapter, Score(self._slope, gmean(values), self._intercept))
+
+        book_scores = ScriptureBookScores()
+        for book, values in confidences_by_book.items():
+            book_scores.add_score(book, Score(self._slope, gmean(values), self._intercept))
+        return segment_scores, chapter_scores, book_scores

--- a/machine/quality_estimation/score.py
+++ b/machine/quality_estimation/score.py
@@ -1,0 +1,4 @@
+class Score:
+    def __init__(self, slope: float, confidence: float, intercept: float) -> None:
+        self.confidence = confidence
+        self.projected_chrf3 = slope * confidence + intercept

--- a/machine/quality_estimation/scripture_book_scores.py
+++ b/machine/quality_estimation/scripture_book_scores.py
@@ -1,0 +1,21 @@
+from collections import defaultdict
+
+from .score import Score
+
+
+class ScriptureBookScores:
+    def __init__(self) -> None:
+        self._segment_usabilities: dict[str, list[float]] = defaultdict(list)
+        self.scores: dict[str, Score] = {}
+
+    def add_score(self, book: str, score: Score) -> None:
+        self.scores[book] = score
+
+    def get_score(self, book: str) -> Score | None:
+        return self.scores.get(book, None)
+
+    def append_segment_usability(self, book: str, usability: float) -> None:
+        self._segment_usabilities[book].append(usability)
+
+    def get_segment_usabilities(self, book: str) -> list[float]:
+        return list(self._segment_usabilities.get(book, []))

--- a/machine/quality_estimation/scripture_book_usability.py
+++ b/machine/quality_estimation/scripture_book_usability.py
@@ -1,0 +1,10 @@
+from .usability_base import UsabilityBase
+from .usability_label import UsabilityLabel
+
+
+class ScriptureBookUsability(UsabilityBase):
+    def __init__(
+        self, book: str, label: UsabilityLabel, projected_chrf3: float, usability: float, confidence: float
+    ) -> None:
+        super().__init__(label, projected_chrf3, usability, confidence)
+        self.book = book

--- a/machine/quality_estimation/scripture_chapter_scores.py
+++ b/machine/quality_estimation/scripture_chapter_scores.py
@@ -1,0 +1,21 @@
+from collections import defaultdict
+
+from .score import Score
+
+
+class ScriptureChapterScores:
+    def __init__(self) -> None:
+        self._segment_usabilities: dict[str, dict[int, list[float]]] = defaultdict(lambda: defaultdict(list))
+        self.scores: dict[str, dict[int, Score]] = defaultdict(dict)
+
+    def add_score(self, book: str, chapter: int, score: Score) -> None:
+        self.scores[book][chapter] = score
+
+    def get_score(self, book: str, chapter: int) -> Score | None:
+        return self.scores.get(book, {}).get(chapter, None)
+
+    def append_segment_usability(self, book: str, chapter: int, usability: float) -> None:
+        self._segment_usabilities[book][chapter].append(usability)
+
+    def get_segment_usabilities(self, book: str, chapter: int) -> list[float]:
+        return list(self._segment_usabilities.get(book, {}).get(chapter, []))

--- a/machine/quality_estimation/scripture_chapter_usability.py
+++ b/machine/quality_estimation/scripture_chapter_usability.py
@@ -1,0 +1,16 @@
+from .scripture_book_usability import ScriptureBookUsability
+from .usability_label import UsabilityLabel
+
+
+class ScriptureChapterUsability(ScriptureBookUsability):
+    def __init__(
+        self,
+        book: str,
+        chapter: int,
+        label: UsabilityLabel,
+        projected_chrf3: float,
+        usability: float,
+        confidence: float,
+    ) -> None:
+        super().__init__(book, label, projected_chrf3, usability, confidence)
+        self.chapter = chapter

--- a/machine/quality_estimation/scripture_segment_score.py
+++ b/machine/quality_estimation/scripture_segment_score.py
@@ -1,0 +1,8 @@
+from ..corpora import ScriptureRef
+from .score import Score
+
+
+class ScriptureSegmentScore(Score):
+    def __init__(self, slope: float, confidence: float, intercept: float, scripture_ref: ScriptureRef) -> None:
+        super().__init__(slope, confidence, intercept)
+        self.scripture_ref = scripture_ref

--- a/machine/quality_estimation/scripture_segment_usability.py
+++ b/machine/quality_estimation/scripture_segment_usability.py
@@ -1,0 +1,16 @@
+from ..corpora import ScriptureRef
+from .scripture_chapter_usability import ScriptureChapterUsability
+from .usability_label import UsabilityLabel
+
+
+class ScriptureSegmentUsability(ScriptureChapterUsability):
+    def __init__(
+        self,
+        scripture_ref: ScriptureRef,
+        label: UsabilityLabel,
+        projected_chrf3: float,
+        usability: float,
+        confidence: float,
+    ) -> None:
+        super().__init__(scripture_ref.book, scripture_ref.chapter_num, label, projected_chrf3, usability, confidence)
+        self.scripture_ref = scripture_ref

--- a/machine/quality_estimation/text_scores.py
+++ b/machine/quality_estimation/text_scores.py
@@ -1,0 +1,21 @@
+from collections import defaultdict
+
+from .score import Score
+
+
+class TextScores:
+    def __init__(self) -> None:
+        self._segment_usabilities: dict[str, list[float]] = defaultdict(list)
+        self.scores: dict[str, Score] = {}
+
+    def add_score(self, target_draft_file_stem: str, score: Score) -> None:
+        self.scores[target_draft_file_stem] = score
+
+    def get_score(self, target_draft_file_stem: str) -> Score | None:
+        return self.scores.get(target_draft_file_stem, None)
+
+    def append_segment_usability(self, text_id: str, usability: float) -> None:
+        self._segment_usabilities[text_id].append(usability)
+
+    def get_segment_usabilities(self, text_id: str) -> list[float]:
+        return list(self._segment_usabilities.get(text_id, []))

--- a/machine/quality_estimation/text_segment_score.py
+++ b/machine/quality_estimation/text_segment_score.py
@@ -1,0 +1,9 @@
+from ..corpora import MultiKeyRef
+from .score import Score
+
+
+class TextSegmentScore(Score):
+    def __init__(self, slope: float, confidence: float, intercept: float, segment_ref: MultiKeyRef) -> None:
+        super().__init__(slope, confidence, intercept)
+        self.segment_ref = segment_ref
+        self.text_id = segment_ref.text_id

--- a/machine/quality_estimation/text_segment_usability.py
+++ b/machine/quality_estimation/text_segment_usability.py
@@ -1,0 +1,16 @@
+from ..corpora import MultiKeyRef
+from .text_usability import TextUsability
+from .usability_label import UsabilityLabel
+
+
+class TextSegmentUsability(TextUsability):
+    def __init__(
+        self,
+        segment_ref: MultiKeyRef,
+        label: UsabilityLabel,
+        projected_chrf3: float,
+        usability: float,
+        confidence: float,
+    ) -> None:
+        super().__init__(segment_ref.text_id, label, projected_chrf3, usability, confidence)
+        self.segment_ref = segment_ref

--- a/machine/quality_estimation/text_usability.py
+++ b/machine/quality_estimation/text_usability.py
@@ -1,0 +1,10 @@
+from .usability_base import UsabilityBase
+from .usability_label import UsabilityLabel
+
+
+class TextUsability(UsabilityBase):
+    def __init__(
+        self, text_id: str, label: UsabilityLabel, projected_chrf3: float, usability: float, confidence: float
+    ) -> None:
+        super().__init__(label, projected_chrf3, usability, confidence)
+        self.text_id = text_id

--- a/machine/quality_estimation/thresholds.py
+++ b/machine/quality_estimation/thresholds.py
@@ -1,0 +1,15 @@
+from .usability_label import UsabilityLabel
+
+
+class Thresholds:
+    def __init__(self, green_threshold: float, yellow_threshold: float) -> None:
+        self.green_threshold = green_threshold
+        self.yellow_threshold = yellow_threshold
+
+    def return_label(self, probability: float) -> UsabilityLabel:
+        if probability >= self.green_threshold:
+            return UsabilityLabel.GREEN
+        elif probability >= self.yellow_threshold:
+            return UsabilityLabel.YELLOW
+        else:
+            return UsabilityLabel.RED

--- a/machine/quality_estimation/usability_base.py
+++ b/machine/quality_estimation/usability_base.py
@@ -1,0 +1,9 @@
+from .usability_label import UsabilityLabel
+
+
+class UsabilityBase:
+    def __init__(self, label: UsabilityLabel, projected_chrf3: float, usability: float, confidence: float) -> None:
+        self.confidence = confidence
+        self.label = label
+        self.projected_chrf3 = projected_chrf3
+        self.usability = usability

--- a/machine/quality_estimation/usability_label.py
+++ b/machine/quality_estimation/usability_label.py
@@ -1,0 +1,7 @@
+from enum import Enum
+
+
+class UsabilityLabel(Enum):
+    RED = 0
+    YELLOW = 1
+    GREEN = 2

--- a/machine/quality_estimation/usability_parameters.py
+++ b/machine/quality_estimation/usability_parameters.py
@@ -2,7 +2,7 @@ from dataclasses import dataclass
 from typing import ClassVar
 
 
-@dataclass
+@dataclass(frozen=True)
 class UsabilityParameters:
     unusable: ClassVar["UsabilityParameters"]
     usable: ClassVar["UsabilityParameters"]

--- a/machine/quality_estimation/usability_parameters.py
+++ b/machine/quality_estimation/usability_parameters.py
@@ -1,0 +1,16 @@
+from dataclasses import dataclass
+from typing import ClassVar
+
+
+@dataclass
+class UsabilityParameters:
+    unusable: ClassVar["UsabilityParameters"]
+    usable: ClassVar["UsabilityParameters"]
+
+    count: float
+    mean: float
+    variance: float
+
+
+UsabilityParameters.unusable = UsabilityParameters(count=97.0, mean=45.85, variance=99.91)
+UsabilityParameters.usable = UsabilityParameters(count=263.0, mean=51.4, variance=95.19)

--- a/tests/quality_estimation/test_chrf3_quality_estimator.py
+++ b/tests/quality_estimation/test_chrf3_quality_estimator.py
@@ -1,0 +1,96 @@
+from pytest import approx
+
+from machine.corpora import MultiKeyRef, ScriptureRef
+from machine.quality_estimation import ChrF3QualityEstimator, UsabilityLabel
+from machine.scripture import VerseRef
+
+
+def test_chrf3_quality_estimator_txt_files() -> None:
+    quality_estimation = ChrF3QualityEstimator(slope=109.6145, intercept=-14.0633)
+
+    confidences = [
+        (MultiKeyRef("MAT.txt", [1]), 0.6220749899712906),
+        (MultiKeyRef("MAT.txt", [2]), 0.5416165991875662),
+        (MultiKeyRef("MRK.txt", [1]), 0.40324150219671917),
+    ]
+
+    usability_text_segments, usability_texts = quality_estimation.estimate_quality(confidences)
+
+    # Segment assertions
+    assert len(usability_text_segments) == 3
+
+    assert usability_text_segments[0].label == UsabilityLabel.GREEN
+    assert usability_text_segments[0].projected_chrf3 == approx(54.12, abs=0.01)
+    assert usability_text_segments[0].usability == approx(0.786, abs=0.001)
+    assert usability_text_segments[0].confidence == approx(confidences[0][1], abs=0.001)
+
+    assert usability_text_segments[1].label == UsabilityLabel.YELLOW
+    assert usability_text_segments[1].projected_chrf3 == approx(45.31, abs=0.01)
+    assert usability_text_segments[1].usability == approx(0.691, abs=0.001)
+    assert usability_text_segments[1].confidence == approx(confidences[1][1], abs=0.001)
+
+    assert usability_text_segments[2].label == UsabilityLabel.RED
+    assert usability_text_segments[2].projected_chrf3 == approx(30.14, abs=0.01)
+    assert usability_text_segments[2].usability == approx(0.465, abs=0.001)
+    assert usability_text_segments[2].confidence == approx(confidences[2][1], abs=0.001)
+
+    # Text level assertions
+    assert len(usability_texts) == 2
+
+    assert usability_texts[0].label == UsabilityLabel.YELLOW
+    assert usability_texts[0].projected_chrf3 == approx(49.56, abs=0.01)
+    assert usability_texts[0].usability == approx(0.738, abs=0.001)
+    assert usability_texts[0].confidence == approx(0.580, abs=0.001)
+
+    assert usability_texts[1].label == UsabilityLabel.RED
+    assert usability_texts[1].projected_chrf3 == approx(30.14, abs=0.01)
+    assert usability_texts[1].usability == approx(0.465, abs=0.001)
+    assert usability_texts[1].confidence == approx(confidences[2][1], abs=0.001)
+
+
+def test_chrf3_quality_estimator_verses() -> None:
+    quality_estimation = ChrF3QualityEstimator(slope=109.6145, intercept=-14.0633)
+
+    confidences = [
+        (ScriptureRef(VerseRef(1, 1, 1)), 0.6220749899712906),
+        (ScriptureRef(VerseRef(1, 1, 2)), 0.5416165991875662),
+        (ScriptureRef(VerseRef(1, 2, 1)), 0.40324150219671917),
+    ]
+
+    usability_segments, usability_chapters, usability_books = quality_estimation.estimate_quality(confidences)
+
+    # Segment assertions
+    assert len(usability_segments) == 3
+    assert usability_segments[0].label == UsabilityLabel.GREEN
+    assert usability_segments[0].projected_chrf3 == approx(54.12, abs=0.01)
+    assert usability_segments[0].usability == approx(0.786, abs=0.001)
+    assert usability_segments[0].confidence == approx(confidences[0][1], abs=0.001)
+
+    assert usability_segments[1].label == UsabilityLabel.YELLOW
+    assert usability_segments[1].projected_chrf3 == approx(45.31, abs=0.01)
+    assert usability_segments[1].usability == approx(0.691, abs=0.001)
+    assert usability_segments[1].confidence == approx(confidences[1][1], abs=0.001)
+
+    assert usability_segments[2].label == UsabilityLabel.RED
+    assert usability_segments[2].projected_chrf3 == approx(30.14, abs=0.01)
+    assert usability_segments[2].usability == approx(0.465, abs=0.001)
+    assert usability_segments[2].confidence == approx(confidences[2][1], abs=0.001)
+
+    # Chapter assertions
+    assert len(usability_chapters) == 2
+    assert usability_chapters[0].label == UsabilityLabel.YELLOW
+    assert usability_chapters[0].projected_chrf3 == approx(49.56, abs=0.01)
+    assert usability_chapters[0].usability == approx(0.738, abs=0.001)
+    assert usability_chapters[0].confidence == approx(0.580, abs=0.001)
+
+    assert usability_chapters[1].label == UsabilityLabel.RED
+    assert usability_chapters[1].projected_chrf3 == approx(30.14, abs=0.01)
+    assert usability_chapters[1].usability == approx(0.465, abs=0.001)
+    assert usability_chapters[1].confidence == approx(confidences[2][1], abs=0.001)
+
+    # Book assertions
+    assert len(usability_books) == 1
+    assert usability_books[0].label == UsabilityLabel.RED
+    assert usability_books[0].projected_chrf3 == approx(42.28, abs=0.01)
+    assert usability_books[0].usability == approx(0.647, abs=0.001)
+    assert usability_books[0].confidence == approx(0.514, abs=0.001)


### PR DESCRIPTION
Fixes #269 

I added a dependency for scipy to use gmean (as silnlp uses this library in its implementation), but if you would prefer I implement that function in machine.py, it is a very straightforward function:

```python
def _gmean(values: List[float]) -> float:
        if not values or any(x <= 0 for x in values):
            return 0.0
        return math.exp(sum(math.log(x) for x in values) / len(values))
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/machine.py/334)
<!-- Reviewable:end -->
