### PR TITLE
Expose SegmentBoundaryAdjuster for external use

### DIFF
--- a/machine/corpora/__init__.py
+++ b/machine/corpora/__init__.py
@@ -30,6 +30,7 @@ from .paratext_project_terms_parser_base import KeyTerm, ParatextProjectTermsPar
 from .paratext_project_text_updater_base import ParatextProjectTextUpdaterBase
 from .paratext_text_corpus import ParatextTextCorpus
 from .place_markers_usfm_update_block_handler import PlaceMarkersAlignmentInfo, PlaceMarkersUsfmUpdateBlockHandler
+from .segment_boundary_adjuster import SegmentBoundaryAdjuster
 from .scripture_element import ScriptureElement
 from .scripture_ref import EMPTY_SCRIPTURE_REF, ScriptureRef
 from .scripture_ref_usfm_parser_handler_base import ScriptureRefUsfmParserHandlerBase, ScriptureTextType
@@ -150,6 +151,7 @@ __all__ = [
     "ScriptureRefUsfmParserHandlerBase",
     "ScriptureTextCorpus",
     "ScriptureTextType",
+    "SegmentBoundaryAdjuster",
     "StandardParallelTextCorpus",
     "Text",
     "TextCorpus",

--- a/machine/corpora/__init__.py
+++ b/machine/corpora/__init__.py
@@ -30,7 +30,6 @@ from .paratext_project_terms_parser_base import KeyTerm, ParatextProjectTermsPar
 from .paratext_project_text_updater_base import ParatextProjectTextUpdaterBase
 from .paratext_text_corpus import ParatextTextCorpus
 from .place_markers_usfm_update_block_handler import PlaceMarkersAlignmentInfo, PlaceMarkersUsfmUpdateBlockHandler
-from .segment_boundary_adjuster import SegmentBoundaryAdjuster
 from .scripture_element import ScriptureElement
 from .scripture_ref import EMPTY_SCRIPTURE_REF, ScriptureRef
 from .scripture_ref_usfm_parser_handler_base import ScriptureRefUsfmParserHandlerBase, ScriptureTextType
@@ -40,6 +39,7 @@ from .scripture_text_corpus import (
     extract_scripture_corpus,
     is_scripture,
 )
+from .segment_boundary_adjuster import SegmentBoundaryAdjuster
 from .standard_parallel_text_corpus import StandardParallelTextCorpus
 from .text import Text
 from .text_corpus import TextCorpus


### PR DESCRIPTION
This PR exposes `SegmentBoundaryAdjuster` so that it can be used by external callers, specifically the verse segmenter in SILNLP.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/machine.py/345)
<!-- Reviewable:end -->
