### PR TITLE
Properly pass alignment info/score to Serval

### DIFF
--- a/machine/jobs/nmt_engine_build_job.py
+++ b/machine/jobs/nmt_engine_build_job.py
@@ -235,7 +235,7 @@ class NmtEngineBuildJob(TranslationEngineBuildJob):
                     for (pt_info, row), (source_segment, target_segment), alignment in zip(
                         pt_batch, segments, alignments, strict=True
                     ):
-                        word_pairs = alignment.to_aligned_word_pairs(include_null=False)
+                        word_pairs = alignment.to_aligned_word_pairs(include_null=True)
                         alignment_model.compute_aligned_word_pair_scores(source_segment, target_segment, word_pairs)
                         pt_info["sourceTokens"] = list(row.source_segment)
                         pt_info["translationTokens"] = list(row.target_segment)


### PR DESCRIPTION
Include NULL alignments.

Is there more we need to do in machine.py to fix this? We are already passing the translation scores (unless there's something weird happening under the hood in thot).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/machine.py/365)
<!-- Reviewable:end -->
